### PR TITLE
dm-check-headers updates

### DIFF
--- a/bin/dm-check-headers.py
+++ b/bin/dm-check-headers.py
@@ -3,42 +3,38 @@
 Diffs the relevant fields of the header to determine if anything has changed in
 the protocol.
 
-Usage: 
-    dm-check-header.py [options] <standards> <logs> <blacklist> <exam>...
+Usage:
+    dm-check-header.py [options] <standards/> <logdir/> <examsdir/>
 
-Arguments: 
+Arguments:
     <standards/>            Folder with subfolders named by tag. Each subfolder
                             has a sample gold standard dicom file for that tag.
 
-    <logs/>                 Folder to contain the outputs (specific errors found)
-                            of this script.
+    <logdir/>               Folder to contain the outputs (specific errors found)
+                            of this script. A log file is created in this
+                            folder for each exam, named: dm-check-headers-<examdir>.log
 
-    <blacklist>             YAML file for recording ignored / processed series.
+    <examsdir/>             Folder with subfolder for each exam to check. Each
+                            exam directory shoul dhave one dicom file sample
+                            from each series to check.
 
-    <exam/>                 Folder with one dicom file sample from each series
-                            to check
-
-Options: 
-    --verbose               Print warnings
+Options:
     --ignore-headers LIST   Comma delimited list of headers to ignore
-
-DETAILS
-    
-    Outputs the number of mismatches per subject to STDOUT.
-    Outputs the full diff of the mismatches to logs/subjectname.log
-    Records analyzed subjects to the blacklist (so these warnings are not continually produced).
-
+    --verbose               Print mismatches to stdout as well as the log file
 """
+
 import sys
+import collections
 from docopt import docopt
 import dicom as dcm
 import datman as dm
+import glob
+import logging as log
 import numpy as np
-import pandas as pd
 import datman.utils
 import os.path
 
-ignored_headers = set([
+DEFAULT_IGNORED_HEADERS = set([
     'AcquisitionDate',
     'AcquisitionTime',
     'AcquisitionNumber',
@@ -95,166 +91,181 @@ ignored_headers = set([
     'WindowWidth',
 ])
 
-integer_tolerances = {
-        # field           : interger difference
-        'ImagingFrequency': 1, 
-        'EchoTime': 5,
+INTEGER_TOLERANCES = {
+    # field           : interger difference
+    'ImagingFrequency': 1,
+    'EchoTime': 5,
 }
 
-decimal_tolerances = {
-        'RepetitionTime': 1
+DECIMAL_TOLERANCES = {
+    'RepetitionTime': 1
 }
 
-def compare_headers(stdpath, stdhdr, cmppath, cmphdr, ignore, logsdir, errors):
+# represents a mismatch between expected (gold standard) and actual
+# headers for a file
+Mismatch = collections.namedtuple(
+    'Mismatch', ['header', 'expected', 'actual', 'tolerance'])
+
+# Configuration object for the tolerances used in header compare
+Tolerances = collections.namedtuple('Tolerances', ['integer', 'decimal'])
+
+DEFAULT_TOLERANCES = Tolerances(
+    integer=INTEGER_TOLERANCES,
+    decimal=DECIMAL_TOLERANCES)
+
+
+def get_gold_standard_headers(path):
+    """Fetches the gold standard headers.
+
+    Expects there to be subfolders named by the tag and containing a single
+    dicom file representing the expected (gold standard) headers.
+
+    Returns a map from tag -> headers.
     """
-    Accepts two pydicom objects and prints out header value differences. 
-    
+    manifest = dm.utils.get_all_headers_in_folder(path, recurse=True)
+    map = {os.path.basename(os.path.dirname(k)): (k, v)
+           for (k, v) in manifest.items()}
+    return map
+
+
+def compare_headers(stdhdr, cmphdr, tolerances=None, ignore_headers=None):
+    """
+    Accepts two pydicom objects and prints out header value differences.
+
     Headers in ignore set are ignored.
+
+    Returns a tuple containing a list of mismatched headers (as a list of
+    Mismatch objects)
     """
+
+    tolerances = tolerances or DEFAULT_TOLERANCES
+    ignore_headers = ignore_headers or []
 
     # get the unignored headers
-    stdhdr_ = set(stdhdr.dir()).difference(ignore)
-    cmphdr_ = set(cmphdr.dir()).difference(ignore)
+    headers = set(stdhdr.dir()).union(cmphdr.dir()).difference(ignore_headers)
 
-    only_stdhdr = stdhdr_.difference(cmphdr_)
-    only_cmphdr = cmphdr_.difference(stdhdr_)
-    both_hdr    = stdhdr_.intersection(cmphdr_)
-  
-    if only_stdhdr and VERBOSE:
-        print("WARNING: [dm-check-headers] {cmppath}: headers in series, not in standard: {list}".format(cmppath=cmppath, list=", ".join(only_stdhdr)))
+    mismatches = []  # list of Mismatches
 
-    if only_cmphdr and VERBOSE:
-        print("WARNING: [dm-check-headers] {cmppath}: headers in standard, not in series: {list}".format(cmppath=cmppath, list=", ".join(only_cmphdr)))
-    
-    for header in both_hdr:
+    for header in headers:
+        if header not in stdhdr.dir():
+            mismatches.append(Mismatch(
+                header=header, expected=None, actual=cmphdr.get(header), tolerance=None))
+            continue
+
+        if header not in cmphdr.dir():
+            mismatches.append(Mismatch(
+                header=header, expected=stdhdr.get(header), actual=None, tolerance=None))
+            continue
+
         stdval = stdhdr.get(header)
         cmpval = cmphdr.get(header)
 
         # integer level tolerance
-        if header in integer_tolerances:
-            n = integer_tolerances[header]
+        if header in tolerances.integer:
+            n = tolerances.integer[header]
 
             stdval_rounded = np.round(float(stdval))
             cmpval_rounded = np.round(float(cmpval))
             difference = np.abs(stdval_rounded - cmpval_rounded)
 
             if difference > n:
-                with open(os.path.join(logsdir, dm.utils.get_subject_from_filename(cmppath) + '.log'), "a") as fname:
-                    fname.write(
-                        "{}: header {}, expected = {}, actual = {} [tolerance = {}]\n".format(
-                            cmppath, header, stdval_rounded, cmpval_rounded, n))
-                errors = errors + 1
+                mismatches.append(Mismatch(
+                    header=header, expected=stdval_rounded, actual=cmpval_rounded, tolerance=n))
 
         # decimal level tolerance
-        elif header in decimal_tolerances:
-            n = decimal_tolerances[header]
+        elif header in tolerances.decimal:
+            n = tolerances.decimal[header]
 
             stdval_rounded = round(float(stdval), n)
             cmpval_rounded = round(float(cmpval), n)
 
             if stdval_rounded != cmpval_rounded:
-                with open(os.path.join(logsdir, dm.utils.get_subject_from_filename(cmppath) + '.log'), "a") as fname:
-                    fname.write(
-                        "{}: header {}, expected = {}, actual = {} [tolerance = {}]\n".format(
-                            cmppath, header, stdval_rounded, cmpval_rounded, n))
-                errors = errors + 1
+                mismatches.append(Mismatch(
+                    header=header, expected=stdval_rounded, actual=cmpval_rounded, tolerance=n))
 
         # no tolerance set
         elif str(cmpval) != str(stdval):
-            with open(os.path.join(logsdir, dm.utils.get_subject_from_filename(cmppath) + '.log'), "a") as fname:
-                fname.write(
-                    "{}: header {}, expected = {}, actual = {}\n".format(
-                        cmppath, header, stdval, cmpval))
-            errors = errors + 1
+            mismatches.append(Mismatch(
+                header=header, expected=stdval, actual=cmpval, tolerance=None))
+
+    return mismatches
 
 
-    return errors
-
-def compare_exam_headers(stdmap, examdir, ignorelist, logsdir, ignored_series, blacklist):
+def compare_exam_headers(stdmap, examdir, ignore_headers, tolerances=None):
     """
     Compares headers for each series in an exam against gold standards
 
     <stdmap> is a map from description -> (cmppath, headers) of all of the
-    standard headers to compare against. 
+    standard headers to compare against.
 
-    <ignorelist> is a list of headers, in addition to the defaults, to ignore.
-
-    <ignored_series> is a list of series to ignore checking. 
+    <ignore_headers> is a list of headers to ignore.
     """
     exam_headers = dm.utils.get_all_headers_in_folder(examdir)
 
-    ignore = ignored_headers.union(ignorelist)
-
-    try:
-        dm.utils.run('rm {}'.format(os.path.join(logsdir, dm.utils.get_subject_from_filename(cmppath) + '.log')))
-    except:
-        pass
-
-    errors = 0 # if this counter gets tripped, we print a single warning to the screen per subject
+    all_mismatches = {}
     for cmppath, cmphdr in exam_headers.iteritems():
-
         ident, tag, series, description = dm.scanid.parse_filename(cmppath)
 
-        if os.path.basename(cmppath) in ignored_series:
-            if VERBOSE: 
-                print("MSG: [dm-check-headers] Ignoring {}".format(cmppath))
-            continue
-
         if tag not in stdmap:
-            if VERBOSE: 
-                print("WARNING: [dm-check-headers] {}: No matching standard for tag '{}'".format(cmppath, tag))
+            log.warning(
+                "{}: No matching standard for tag '{}'".format(cmppath, tag))
             continue
 
         stdpath, stdhdr = stdmap[tag]
+        mismatches = compare_headers(
+            stdhdr, cmphdr, tolerances, ignore_headers)
+        if mismatches:
+            all_mismatches[cmppath] = mismatches
 
-        errors = compare_headers(stdpath, stdhdr, cmppath, cmphdr, ignore, logsdir, errors)
-        dm.yamltools.blacklist_series(blacklist, 'dm-check-headers', os.path.basename(cmppath), 'done')
+    return all_mismatches
 
-    if errors > 0:
-        print('ERROR: [dm-check-headers] {} header mismatches for {}'.format(errors, dm.utils.get_subject_from_filename(cmppath)))
 
 def main():
-    global VERBOSE
+    arguments = docopt(__doc__)
+    standardsdir = arguments['<standards/>']
+    logsdir = arguments['<logdir/>']
+    examsdir = arguments['<examsdir/>']
+    verbose = arguments['--verbose']
+    ignore_headers = arguments['--ignore-headers']
 
-    arguments    = docopt(__doc__)
-    standardsdir = arguments['<standards>']
-    logsdir      = arguments['<logs>']
-    examdirs     = arguments['<exam>']
-    blacklist    = arguments['<blacklist>']
-    ignorelist   = arguments['--ignore-headers']
-    VERBOSE      = arguments['--verbose']
+    log.basicConfig(
+        level=log.WARN, format="[dm-check-headers] %(levelname)s: %(message)s")
 
-    logsdir = dm.utils.define_folder(logsdir)
+    if verbose:
+        log.getLogger('').setLevel(log.INFO)
 
-    # check inputs
-    if os.path.isdir(logsdir) == False:
-        print('ERROR: [dm-check-headers] Log directory {} does not exist'.format(logsdir))
-        sys.exit()
-    if os.path.isdir(standardsdir) == False:
-        print('ERROR: [dm-check-headers] Standards directory {} does not exist'.format(standardsdir))
-        sys.exit()
+    if not os.path.isdir(logsdir):
+        log.error('Log directory {} does not exist'.format(logsdir))
+        sys.exit(1)
+    if not os.path.isdir(standardsdir):
+        log.error('Standards directory {} does not exist'.format(standardsdir))
+        sys.exit(1)
+    if not os.path.isdir(examsdir):
+        log.error('Exams directory {} does not exist'.format(examsdir))
+        sys.exit(1)
 
-    dm.yamltools.touch_blacklist_stage(blacklist, 'dm-check-headers')
+    ignore_headers = ignore_headers and ignore_headers.split(",") or []
+    ignore_headers = DEFAULT_IGNORED_HEADERS.union(ignore_headers)
 
-    if ignorelist:
-        ignorelist = ignorelist.split(",")
-    else:
-        ignorelist = []
+    stdmap = get_gold_standard_headers(standardsdir)
+    for examdir in glob.glob(examsdir + '/*/'):
+        if '_PHA_' in examdir:  # ignore phantoms
+            continue
 
-    try:
-        ignored_series = dm.yamltools.list_series(blacklist, 'dm-check-headers')
-    except:
-        ignored_series = []
-    manifest = dm.utils.get_all_headers_in_folder(standardsdir, recurse=True)
-   
-    # map tag name to headers 
-    stdmap = { os.path.basename(os.path.dirname(k)):(k,v) for (k,v) in manifest.items()}
+        logfile = os.path.join(logsdir, "dm-check-headers-{}.log".format(
+            os.path.basename(os.path.normpath(examdir))))
 
-    # remove phantoms from examdirs
-    examdirs = filter(lambda x: '_PHA_' not in x, examdirs)
+        all_mismatches = compare_exam_headers(stdmap, examdir, ignore_headers)
+        if not all_mismatches:
+            continue
 
-    for examdir in examdirs:
-        compare_exam_headers(stdmap, examdir, ignorelist, logsdir, ignored_series, blacklist)
-        
-if __name__ == '__main__': 
+        with open(logfile, "w") as fname:
+            for path, mismatches in all_mismatches.iteritems():
+                for m in mismatches:
+                    message = "{}: header {}, expected = {}, actual = {} [tolerance = {}]".format(
+                        path, m.header, m.expected, m.actual, m.tolerance)
+                    log.info(message)
+                    fname.write(message + "\n")
+
+if __name__ == '__main__':
     main()

--- a/bin/dm-check-headers.py
+++ b/bin/dm-check-headers.py
@@ -15,7 +15,7 @@ Arguments:
                             folder for each exam, named: dm-check-headers-<examdir>.log
 
     <examsdir/>             Folder with subfolder for each exam to check. Each
-                            exam directory shoul dhave one dicom file sample
+                            exam directory should have one dicom file sample
                             from each series to check.
 
 Options:
@@ -258,6 +258,9 @@ def main():
         all_mismatches = compare_exam_headers(stdmap, examdir, ignore_headers)
         if not all_mismatches:
             continue
+
+        if not os.path.exists(logfile):  # display warning on first encounter
+            log.warn('{} mismatches for exam {}'.format(len(all_mismatches), examdir))
 
         with open(logfile, "w") as fname:
             for path, mismatches in all_mismatches.iteritems():

--- a/tests/test_dm-check-headers.py
+++ b/tests/test_dm-check-headers.py
@@ -1,0 +1,78 @@
+from nose.tools import *
+import importlib
+import sys
+from StringIO import StringIO
+
+check_headers = importlib.import_module('bin.dm-check-headers')
+
+
+class mock_header(dict):
+
+    def __init__(self, *args, **kwargs):
+        dict.__init__(self, *args, **kwargs)
+
+    def dir(self):
+        return self.keys()
+
+
+def test_empty_headers():
+    stdhdr = mock_header()
+    cmphdr = mock_header()
+    mismatches = check_headers.compare_headers(stdhdr, cmphdr)
+
+    expected = []
+    assert mismatches == expected
+
+
+def test_header_in_std_only():
+    stdhdr = mock_header({"do-not-ignore": 1})
+    cmphdr = mock_header()
+
+    mismatches = check_headers.compare_headers(stdhdr, cmphdr)
+
+    expected = [check_headers.Mismatch(
+        header="do-not-ignore",
+        expected=1,
+        actual=None,
+        tolerance=None)]
+    assert mismatches == expected
+
+
+def test_header_in_cmp_only():
+    stdhdr = mock_header()
+    cmphdr = mock_header({"do-not-ignore": 1})
+
+    mismatches = check_headers.compare_headers(stdhdr, cmphdr)
+
+    expected = [check_headers.Mismatch(
+        header="do-not-ignore",
+        expected=None,
+        actual=1,
+        tolerance=None)]
+    assert mismatches == expected
+
+
+def test_header_single_match():
+    stdhdr = mock_header({"same": 1})
+    cmphdr = mock_header({"same": 1})
+
+    mismatches = check_headers.compare_headers(stdhdr, cmphdr)
+
+    expected = []
+    assert mismatches == expected
+
+
+def test_header_single_mismatch():
+    stdhdr = mock_header({"same": 1})
+    cmphdr = mock_header({"same": 2})
+
+    mismatches = check_headers.compare_headers(stdhdr, cmphdr)
+
+    expected = [check_headers.Mismatch(
+        header="same",
+        expected=1,
+        actual=2,
+        tolerance=None)]
+    assert mismatches == expected
+
+# vim: set ts=4 sw=4 :


### PR DESCRIPTION
This update includes the following:

- removed blacklist and checklist functions
- now called with the top level exams dir (e.g. data/dcm) and not a list
  of exam directories
- log files are named `dm-check-headers-<exam>.log`
- only runtime errors are printed to stdout
- refactored significantly to allow testing
- added tests

Let me know what you think. Merging this will require updating all of the `run.sh` scripts to call this script properly (since the arguments have changed), and it also means that until the QC document includes the header differences, there will be no warnings printed to `run.sh` on header mismatches. (I could add a warning to stdout to this PR which we could remove later.)