### PR TITLE
Blacklist issues

### DIFF
--- a/assets/blacklist-rm.sh
+++ b/assets/blacklist-rm.sh
@@ -2,23 +2,41 @@
 #
 # Finds and removes anything listed on the given blacklist.
 #
-# Author: Dawn E.A. Smith     Email: Dawn.Smith@camh.ca
+# Author: Dawn E.A. Smith     Email: d.eileensmith@gmail.com
 
 function usage() {
 echo "
 Usage:
-    blacklist-rm.sh <datadir> <blacklist>
+    blacklist-rm.sh [options] <datadir> <blacklist>
 
     All inputs should be full paths.
 
-    <datadir> is the location of the parent directory of all data
-    being managed for this project (e.g. /archive/data-2.0/ANDT/data).
+Arguments:
+    <datadir>     The location of the parent directory of all data
+                  being managed for this project (e.g.
+                  /archive/data-2.0/ANDT/data).
 
-    <blacklist> is the full path to the blacklist.csv file
-    (e.g. /archive/data-2.0/ANDT/metadata/blacklist.csv).
+    <blacklist>   is the full path to the blacklist.csv file
+                  (e.g. /archive/data-2.0/ANDT/metadata/blacklist.csv).
+
+Options:
+    -v            Verbose. Output message indicating name of every file
+                  being deleted.
 "
 exit
 }
+
+VERBOSE=0
+
+while getopts "v" OPTION
+do
+  case $OPTION in
+    v)
+      VERBOSE=1
+      shift
+      ;;
+  esac
+done
 
 if [ $# -ne 2 ]
 then
@@ -43,8 +61,16 @@ done < $bl
 
 while read fname
 do
-  echo "Deleting $fname"
-  rm "$fname"
+  # If blacklist accidentally lists same series twice, will
+  # attempt to remove it twice. This stops "file does not exist" error
+  if [ -e $fname ]
+  then
+    if [ $VERBOSE == 1 ]
+    then
+      echo "Deleting $fname"
+    fi
+    rm "$fname"
+  fi
 done < "$tmp"
 
 rm "$tmp"

--- a/assets/blacklist-rm.sh
+++ b/assets/blacklist-rm.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Finds and removes anything listed on the given blacklist.
+#
+# Author: Dawn E.A. Smith     Email: Dawn.Smith@camh.ca
+
+function usage() {
+echo "
+Usage:
+    blacklist-rm.sh <datadir> <blacklist>
+
+    All inputs should be full paths.
+
+    <datadir> is the location of the parent directory of all data
+    being managed for this project (e.g. /archive/data-2.0/ANDT/data).
+
+    <blacklist> is the full path to the blacklist.csv file
+    (e.g. /archive/data-2.0/ANDT/metadata/blacklist.csv).
+"
+exit
+}
+
+if [ $# -ne 2 ]
+then
+  usage
+  exit 1;
+fi
+
+data="${1}"
+bl="${2}"
+
+# Temp file to store all found file names
+tmp=$(mktemp /tmp/series.XXXXXX)
+
+while IFS=" ", read series reason
+do
+  # Skip the first line column headers
+  if [ $series != "series" ]
+  then
+    find $data -name $series* >> $tmp
+  fi
+done < $bl
+
+while read fname
+do
+  echo "Deleting $fname"
+  rm "$fname"
+done < "$tmp"
+
+rm "$tmp"

--- a/bin/qc-html.py
+++ b/bin/qc-html.py
@@ -11,6 +11,7 @@ Options:
     --dbdir DIR             Folder for the database (default, same as --qcdir)
     --project-settings YML  File with project settings (to read expected file list from)
     --subject SCANID        Scan ID to QC for. E.g. DTI_CMH_H001_01_01
+    --rewrite               Rewrite the html of an existing qc page
     --verbose               Be chatty
     --debug                 Be extra chatty
     --dry-run               Don't actually do any work
@@ -60,8 +61,11 @@ logging.basicConfig(level=logging.WARN,
     format="[%(name)s] %(levelname)s: %(message)s")
 logger = logging.getLogger(os.path.basename(__file__))
 
+DEBUG = False
+VERBOSE = False
 DRYRUN = False
 FIGDPI = 144
+REWRITE = False
 
 # adds qascripts to the environment
 ASSETS = '{}/assets'.format(os.path.dirname(dm.utils.script_path()))
@@ -698,9 +702,9 @@ def fmri_qc(fpath, qcpath, qchtml, cur):
 
     if ntrs < 20:
         return
-
+    
     filename = os.path.basename(fpath)
-    filestem = filename.replace('.nii.gz','')
+    filestem = nifti_basename(fpath)
     tmpdir = tempfile.mkdtemp(prefix='qc-')
 
     run('3dvolreg \
@@ -848,7 +852,28 @@ def add_bvec_checks(fpath, qchtml, logdata):
     for l in lines:
         qchtml.write('<tr><td>{}</td></tr>'.format(l))
     qchtml.write('</table>\n')
-
+    
+def add_old_image(fpath, qcpath, qchtml, tag):
+    fname = nifti_basename(fpath)
+    fname = os.path.join(qcpath, fname)
+    
+    if os.path.exists(fname + '.png'):
+        add_pic_to_html(qchtml, fname + '.png')
+        return
+    elif os.path.exists(fname + '_BOLD.png'):
+        add_pic_to_html(qchtml, fname + '_BOLD.png')
+        add_pic_to_html(qchtml, fname + '_fmriplots.png')
+        add_pic_to_html(qchtml, fname + '_SNR.png')
+        add_pic_to_html(qchtml, fname + '_Spikes.png')
+    elif os.path.exists(fname + '_B0.png'):
+        add_pic_to_html(qchtml, fname + '_B0.png')
+        add_pic_to_html(qchtml, fname + '_dti4d.png')
+        add_pic_to_html(qchtml, fname + '_spikes.png')
+    elif tag == 'PDT2':
+        add_pic_to_html(qchtml, fname.replace('_PDT2_','_PD_') + '.png')
+        add_pic_to_html(qchtml, fname.replace('_PDT2_', '_T2_') + '.png')
+        
+        
 ###############################################################################
 # MAIN
 
@@ -868,9 +893,15 @@ def qc_folder(scanpath, subject, qcdir, cur, pconfig, QC_HANDLERS):
     qcpath = dm.utils.define_folder(os.path.join(qcdir,subject))
 
     htmlfile = os.path.join(qcpath, 'qc_{}.html'.format(subject))
-    if os.path.exists(htmlfile):
+    if os.path.exists(htmlfile) and not REWRITE:
         logger.debug("{} exists, skipping.".format(htmlfile))
         return
+
+    if REWRITE:
+        try: 
+            os.remove(htmlfile)
+        except:
+            print("{} does not exist. Reconstructing html file from any images present.".format(htmlfile))
 
     qchtml = open(htmlfile,'a')
     qchtml.write('<HTML><TITLE>{} qc</TITLE>\n'.format(subject))
@@ -952,7 +983,12 @@ def qc_folder(scanpath, subject, qcdir, cur, pconfig, QC_HANDLERS):
                 add_header_checks(fname, qchtml, header_check_log)
             if bvecs_check_log:
                 add_bvec_checks(fname, qchtml, bvecs_check_log)
-            QC_HANDLERS[tag](fname, qcpath, qchtml, cur)
+                
+            if not REWRITE:    
+                QC_HANDLERS[tag](fname, qcpath, qchtml, cur)
+            else:
+                add_old_image(fname, qcpath, qchtml, tag)
+                
             qchtml.write('<br>')
 
     qchtml.close()
@@ -964,6 +1000,7 @@ def main():
     global VERBOSE
     global DEBUG
     global DRYRUN
+    global REWRITE
 
     QC_HANDLERS = {   # map from tag to QC function
             "T1"            : t1_qc,
@@ -1006,13 +1043,14 @@ def main():
     dbdir     = arguments['--dbdir']
     ymlfile   = arguments['--project-settings']
     scanid    = arguments['--subject']
-    verbose   = arguments['--verbose']
-    debug     = arguments['--debug']
+    REWRITE   = arguments['--rewrite']
+    VERBOSE   = arguments['--verbose']
+    DEBUG     = arguments['--debug']
     DRYRUN    = arguments['--dry-run']
 
-    if verbose:
+    if VERBOSE:
         logging.getLogger().setLevel(logging.INFO)
-    if debug:
+    if DEBUG:
         logging.getLogger().setLevel(logging.DEBUG)
 
     if scanid:

--- a/bin/qc-html.py
+++ b/bin/qc-html.py
@@ -167,7 +167,7 @@ def qchtml_writetable(qchtml, exportinfo):
     for row in range(0,len(exportinfo)):
         qchtml.write('<tr><td>{}</td>'.format(exportinfo.loc[row,'tag'])) ## table new row
         qchtml.write('<td><a href="#{}">{}</a></td>'.format(exportinfo.loc[row,'bookmark'],exportinfo.loc[row,'File']))
-        qchtml.write('<td>{}</td></tr>'.format(exportinfo.loc[row,'Note'])) ## table new row
+        qchtml.write('<td><font color="#FF0000">{}</font></td></tr>'.format(exportinfo.loc[row,'Note'])) ## table new row
 
     ##end table
     qchtml.write('</table>\n')


### PR DESCRIPTION
The new generated run scripts always set the --blacklist option for xnat-extract.py without checking if a blacklist.csv file exists, which may throw errors when xnat-extract.py tries to parse the table. The changes should handle this situation. 

The issues with xnat-extract.py failing to respect blacklists doesn't seem to be due to a bug, but is because some run.sh scripts don't set the blacklist option (for example the ANDT archive) so it's using the default of an empty list. 