### PR TITLE
Updated tests, made proc_freesurfer FS 6 compatible and added log scraping

### DIFF
--- a/bin/dm-qc-report.py
+++ b/bin/dm-qc-report.py
@@ -845,8 +845,8 @@ def check_for_repeat_session(subject):
     try:
         db_session = subject.get_db_object()
     except ImportError:
-        logger.error("Cannot access dashboard database, {} may become out of date "
-                "if repeat sessions exist".format(subject.full_id))
+        logger.error("Cannot access dashboard database, {} QC may become out of "
+                "date if repeat sessions exist".format(subject.full_id))
         return
 
     # db_session is None if entry doesn't exist in dashboard

--- a/bin/dm-qc-report.py
+++ b/bin/dm-qc-report.py
@@ -108,6 +108,10 @@ logger = logging.getLogger(os.path.basename(__file__))
 
 REWRITE = False
 
+SLICER_GAP = 2
+SLICER_RES = 1600
+SLICER_FMRI_RES = 600
+
 def random_str(n):
     """generates a random string of length n"""
     return(''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(n)))
@@ -197,24 +201,24 @@ def fmri_qc(file_name, qc_dir, report):
     image_corr = output_name + '_corr.png'
 
     if not os.path.isfile(image_raw):
-        slicer(file_name, image_raw, 2, 600)
+        slicer(file_name, image_raw, SLICER_GAP, SLICER_FMRI_RES)
     add_image(report, image_raw, title='BOLD montage')
 
     if not os.path.isfile(image_sfnr):
-        slicer(os.path.join(qc_dir, base_name + '_sfnr.nii.gz'), image_sfnr, 2,
-                600)
+        slicer(os.path.join(qc_dir, base_name + '_sfnr.nii.gz'), image_sfnr,
+                SLICER_GAP, SLICER_FMRI_RES)
     add_image(report, image_sfnr, title='SFNR map')
 
     if not os.path.isfile(image_corr):
-        slicer(os.path.join(qc_dir, base_name + '_corr.nii.gz'), image_corr, 2,
-                600)
+        slicer(os.path.join(qc_dir, base_name + '_corr.nii.gz'), image_corr,
+                SLICER_GAP, SLICER_FMRI_RES)
     add_image(report, image_corr, title='correlation map')
 
 def anat_qc(filename, qc_dir, report):
 
     image = os.path.join(qc_dir, datman.utils.nifti_basename(filename) + '.png')
     if not os.path.isfile(image):
-        slicer(filename, image, 5, 1600)
+        slicer(filename, image, 5, SLICER_RES)
     add_image(report, image)
 
 def dti_qc(filename, qc_dir, report):
@@ -237,7 +241,7 @@ def dti_qc(filename, qc_dir, report):
 
     image = os.path.join(qc_dir, basename + '_b0.png')
     if not os.path.isfile(image):
-        slicer(filename, image, 2, 1600)
+        slicer(filename, image, SLICER_GAP, SLICER_RES)
     add_image(report, image, title='b0 montage')
     add_image(report, os.path.join(qc_dir, basename + '_directions.png'),
             title='bvec directions')

--- a/bin/dm_proc_freesurfer.py
+++ b/bin/dm_proc_freesurfer.py
@@ -327,6 +327,10 @@ def main():
     debug     = arguments['--debug']
     PARALLEL = arguments['--parallel']
     DRYRUN    = arguments['--dry-run']
+    # If you add an option/argument that needs to be propagated to subject jobs
+    # after a batch submit make sure to add it to create_command()
+    # If it needs to be propagated to recon-all add it to
+    # get_freesurfer_arguments()
 
     config = load_config(study)
 

--- a/bin/dm_proc_freesurfer.py
+++ b/bin/dm_proc_freesurfer.py
@@ -46,7 +46,7 @@ def write_lines(output_file, lines):
         logger.debug("Dry-run set. Skipping write of {} to {}.".format(lines,
                 output_file))
         return
-    with open(output_file, 'a') as output_stream:
+    with open(output_file, 'w') as output_stream:
         output_stream.writelines(lines)
 
 def submit_job(cmd, i, walltime="24:00:00"):
@@ -140,9 +140,6 @@ def get_freesurfer_arguments(config, site):
 
     return " ".join(args)
 
-def make_arg_string(key, value):
-    return "-{} {}".format(key, value)
-
 def get_site_exportinfo(config, site):
     try:
         site_info = config.study_config['Sites'][site]['ExportInfo']
@@ -170,6 +167,9 @@ def get_optional_images(subject, blacklist, config, error_log):
         else:
             optional_files.extend(found_files)
     return optional_files
+
+def make_arg_string(key, value):
+    return "-{} {}".format(key, value)
 
 def get_anatomical_images(key, subject, blacklist, config, error_log):
     input_tags = get_freesurfer_setting(config, key)
@@ -294,6 +294,7 @@ def get_freesurfer_folders(freesurfer_dir, qc_subjects):
     return fs_data
 
 def update_aggregate_log(config, qc_subjects, destination):
+    logger.info("Updating aggregate log")
     freesurfer_dir = config.get_path('freesurfer')
     site_fs_folders = get_freesurfer_folders(freesurfer_dir, qc_subjects)
 
@@ -326,6 +327,7 @@ def update_aggregate_log(config, qc_subjects, destination):
     write_lines(destination, log)
 
 def update_aggregate_stats(config):
+    logger.info("Updating aggregate stats")
     freesurfer_dir = config.get_path('freesurfer')
     enigma_ctx = os.path.join(config.system_config['DATMAN_ASSETSDIR'],
             'ENGIMA_ExtractCortical.sh')
@@ -418,7 +420,7 @@ def main():
         if subject.is_phantom:
             sys.exit('Subject {} is a phantom, cannot be analyzed'.format(scanid))
 
-        run_freesurfer(subject, blacklisted_series, config)
+        run_freesurfer(subject, blacklisted_series, config, resubmit)
         return
 
     # batch mode

--- a/bin/dm_proc_freesurfer.py
+++ b/bin/dm_proc_freesurfer.py
@@ -237,13 +237,16 @@ def run_freesurfer(subject, blacklist, config, resubmit=False):
     args = get_freesurfer_arguments(config, subject.site)
 
     scripts_dir = os.path.join(output_dir, 'scripts')
-    if resubmit and os.path.exists(scripts_dir):
+    if outputs_exist(scripts_dir):
+        # If outputs exist and the script didnt return above, it means
+        # 'resubmit' == True and the subject must be restarted
         remove_IsRunning(scripts_dir)
         input_files = []
     else:
         input_files = get_anatomical_images('i', subject, blacklist, config,
                 error_log)
-        optional_files = get_optional_images(subject, blacklist, config, error_log)
+        optional_files = get_optional_images(subject, blacklist, config,
+                error_log)
         input_files.extend(optional_files)
 
     command = "recon-all {args} -subjid {subid} {inputs}".format(args=args,

--- a/bin/dm_proc_freesurfer.py
+++ b/bin/dm_proc_freesurfer.py
@@ -277,6 +277,9 @@ def update_aggregate_stats(config):
             config.study_config['STUDY_TAG']), dryrun=DRYRUN)
 
 def get_blacklist(qc_subjects, scanid):
+    # This function is here as bug prevention: If a subject ID is given that
+    # isnt signed off in the checklist.csv this will catch the key error here
+    # instead of later on after work may have been done
     try:
         blacklisted_series = qc_subjects[scanid]
     except KeyError:
@@ -343,7 +346,8 @@ def main():
     check_input_paths(config)
     qc_subjects = config.get_subject_metadata()
 
-    LOG_DIR = make_error_log_dir(config.get_path('freesurfer'))
+    fs_path = config.get_path('freesurfer')
+    LOG_DIR = make_error_log_dir(fs_path)
 
     if scanid:
         # single subject mode
@@ -357,12 +361,12 @@ def main():
 
     else:
         # batch mode
-        fs_path = config.get_path('freesurfer')
         update_aggregate_stats(config)
         destination = os.path.join(fs_path, 'freesurfer_aggregate_log.csv')
         update_aggregate_log(config, qc_subjects, destination)
 
         fs_subjects = get_new_subjects(config, qc_subjects)
+        logger.debug("Running on subjects: {}".format(fs_subjects))
 
         # Change to freesurfer directory, because qbatch leaves .qbatch
         # folders in the current working directory

--- a/datman/fs_log_scraper.py
+++ b/datman/fs_log_scraper.py
@@ -86,9 +86,16 @@ def verify_standards(standards_dict, expected_keys):
             "standards".format(key))
 
 def check_diff(log_field, standards_field):
-    if log_field != standards_field:
-        return log_field
-    return ''
+    diffs = ''
+    if isinstance(log_field, str):
+        sorted_args = sorted(log_field.split())
+        sorted_standards = sorted(standards_field.split())
+        if sorted_args != sorted_standards:
+            diffs = log_field
+    else:
+        if log_field != standards_field:
+            diffs = log_field
+    return diffs
 
 class FSLog(object):
 

--- a/tests/test_dm2-xnat-upload.py
+++ b/tests/test_dm2-xnat-upload.py
@@ -38,22 +38,6 @@ class CheckFilesExist(unittest.TestCase):
     archive_experiment_id = '1.2.840.113619.6.336.' \
                              '254801968553430904107911738210738061468'
 
-    @patch('bin.dm2-xnat-upload.missing_resource_data')
-    @patch('datman.utils.get_archive_headers')
-    def test_returns_true_when_all_data_present_in_xnat_session(self,
-            mock_headers, mock_missing_resources):
-        # Set up
-        mock_headers.return_value = self.__generate_mock_headers()
-        mock_missing_resources.return_value = False
-        xnat_session = self.__get_xnat_session(self.session)
-
-        # Run
-        files_exist = upload.check_files_exist(self.archive, xnat_session,
-                                               self.ident)
-
-        # Assert
-        assert files_exist
-
     @raises(Exception)
     @patch('bin.dm2-xnat-upload.missing_resource_data')
     @patch('datman.utils.get_archive_headers')

--- a/tests/test_fs_log_scraper.py
+++ b/tests/test_fs_log_scraper.py
@@ -179,6 +179,32 @@ class TestVerifyStandards(unittest.TestCase):
         # Function always passes if extra key doesnt cause exception
         assert True
 
+class CheckDiff(unittest.TestCase):
+
+    def test_no_diffs_returns_empty_string(self):
+        log_field = 'kernel1234'
+        standard_field = 'kernel1234'
+
+        diffs = scraper.check_diff(log_field, standard_field)
+
+        assert diffs == ''
+
+    def test_order_of_args_string_doesnt_fool_comparison(self):
+        subject_args = '-parallel -notal-check -qcache'
+        standard_args = '-qcache -parallel -notal-check'
+
+        diffs = scraper.check_diff(subject_args, standard_args)
+
+        assert not diffs
+
+    def test_returned_differences_are_string(self):
+        subject_args = 'kernel1'
+        standard_args = 'kernel2'
+
+        diffs = scraper.check_diff(subject_args, standard_args)
+
+        assert isinstance(diffs, str)
+
 # A timezone class, to fill in the expected (but not used) datetime timezone
 class EST(datetime.tzinfo):
 


### PR DESCRIPTION
Removed/updated + added some tests. 

Added proc_freesurfer upgrades:
- Scrapes the freesurfer output logs to check for differences in how each subject was run
- Able to take T2s and Flairs as additional input niftis
- Able to resubmit all timed out subjects by setting a single flag
- Able to log to a remote log server
- Can use FS 6's parallel flag to run each job in parallel
- Switched to qbatch, so all freesurfer job logs are stored in one directory

Small change to qc-report's code that checks for repeat sessions to ensure the script still runs for installations that don't have a dashboard set up.


