### PR TITLE
Bug fix: DTI configuration resolution

### DIFF
--- a/datman/config.py
+++ b/datman/config.py
@@ -80,18 +80,16 @@ class config(object):
         if study_name.lower() in valid_projects.keys():
             study_name = study_name.upper()
         else:
-            study_name = self.map_xnat_archive_to_project(study_name)
-
-        if not study_name:
-            logger.error('Invalid project:{}'.format(study_name))
-            raise KeyError
+            # DTI is mapped to DTI15T and DTI3T so it's not safe to guess based
+            # only on the study_name
+            raise RuntimeError("Study name not recognized: {}".format(study_name))
 
         self.study_name = study_name
 
         config_path = self.system_config['CONFIG_DIR']
 
         project_settings_file = os.path.join(config_path,
-                                             self.site_config['Projects'][study_name])
+                self.site_config['Projects'][study_name])
 
         self.study_config = self.load_yaml(project_settings_file)
         self.study_config_name = project_settings_file

--- a/datman/scan.py
+++ b/datman/scan.py
@@ -147,9 +147,9 @@ class Scan(DatmanNamed):
             raise datman.scanid.ParseException(message)
 
         try:
-            self.project = config.map_xnat_archive_to_project(ident.study)
+            self.project = config.map_xnat_archive_to_project(subject_id)
         except Exception as e:
-            logger.error('Failed getting project from config:{}'
+            logger.error('Failed getting project from config: {}'
                          .format(str(e)))
 
         DatmanNamed.__init__(self, ident)


### PR DESCRIPTION
Config.py had quietly been mapping all 'DTI' tags to DTI3T since config.py was written. I fixed the bug last week but now other things started failing due to map_xnat_archive_to_project allowing things to be mapped only by the study ID and not being able to resolve it for DTI without a site ID as well.