### PR TITLE
Cleaned up tag configuration access and redundant tags

### DIFF
--- a/bin/dm_proc_fmri.py
+++ b/bin/dm_proc_fmri.py
@@ -48,10 +48,11 @@ def check_inputs(config, tag, path, expected_tags):
     n_found = len(expected_tags)
 
     site = sid.parse_filename(expected_tags[0])[0].site
+    tag_info = config.get_tags(site)
 
     try:
-        if tag in config.study_config['Sites'][site]['ExportInfo'].keys():
-            n_expected = config.study_config['Sites'][site]['ExportInfo'][tag]['Count']
+        if tag in tag_info:
+            n_expected = tag_info.get(tag, 'Count')
         elif tag in config.study_config['Sites'][site]['links'].keys():
             n_expected = config.study_config['Sites'][site]['links'][tag]['Count']
         else:
@@ -372,4 +373,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/bin/dm_proc_freesurfer.py
+++ b/bin/dm_proc_freesurfer.py
@@ -128,22 +128,11 @@ def get_freesurfer_arguments(config, site):
     if PARALLEL:
         args.append('-parallel')
 
-    # not compatible with freesurfer 6
-    #try:
-    #    nu_iter = get_freesurfer_setting(config, 'nu_iter')
-    #    if isinstance(nu_iter, dict):
-    #        site_iter = nu_iter[site]
-    #    else:
-    #        site_iter = nu_iter
-    #    args.append('-nuiterations {}'.format(site_iter))
-    #except KeyError:
-    #   pass
-
     return " ".join(args)
 
 def get_site_exportinfo(config, site):
     try:
-        site_info = config.study_config['Sites'][site]['ExportInfo']
+        site_info = config.get_tags(site)
     except KeyError:
         logger.error("Can't retrieve export info for site {}".format(site))
         sys.exit(1)
@@ -182,7 +171,7 @@ def get_anatomical_images(key, cmd_line_arg, subject, blacklist, config, error_l
 
     inputs = []
     for tag in input_tags:
-        n_expected = site_info[tag]['Count']
+        n_expected = site_info.get(tag, 'Count')
         candidates = filter(lambda nii: utils.splitext(nii.path)[0] not in blacklist,
                 subject.get_tagged_nii(tag))
 

--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -484,7 +484,8 @@ def find_all_tech_notes(path):
     session = ident.get_full_subjectid_with_timepoint()
     session_paths = glob.glob(os.path.join(base_dir, session) + '*')
     for path in session_paths:
-        ident = datman.scanid.parse(path)
+        base_name = os.path.basename(path)
+        ident = datman.scanid.parse(base_name)
         # Some resource folders don't have a repeat number,
         # this is an error and should be ignored
         if ident.session:

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -870,29 +870,5 @@ def export_dcm_command(seriesdir, outputdir, stem):
 
     datman.utils.run(cmd, DRYRUN)
 
-
-def parse_exportinfo(exportinfo):
-    """
-    Takes the dictionary structure from project_settings.yaml and returns a
-    pattern:tag dictionary.
-
-    If multiple patterns are specified in the configuration file, these are
-    joined with an '|' (OR) symbol.
-    """
-    tags = exportinfo.keys()
-    patterns = [tagtype["Pattern"] for tagtype in exportinfo.values()]
-
-    regex = []
-    for pattern in patterns:
-        if type(pattern) == list:
-            regex.append(("|").join(pattern))
-        else:
-            regex.append(pattern)
-
-    tagmap = dict(zip(regex, tags))
-
-    return tagmap
-
-
 if __name__ == '__main__':
     main()

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -602,7 +602,7 @@ def process_scans(xnat_project, session_label, experiment_label, scans):
 
         # first check if the scan has already been processed
         try:
-            export_formats = cfg.get_key(['ExportSettings', tag])
+            export_formats = cfg.get_key(['ExportSettings', tag, 'formats'])
         except KeyError:
             logger.error('Export settings for tag:{} not found for study:{}'
                          .format(tag, cfg.study_name))

--- a/datman/scan.py
+++ b/datman/scan.py
@@ -149,8 +149,8 @@ class Scan(DatmanNamed):
         try:
             self.project = config.map_xnat_archive_to_project(subject_id)
         except Exception as e:
-            logger.error('Failed getting project from config: {}'
-                         .format(str(e)))
+            message = 'Failed getting project from config: {}'.format(str(e))
+            raise Exception(message)
 
         DatmanNamed.__init__(self, ident)
 


### PR DESCRIPTION
Changes:

- Removes the redundant list of tags in dm_qc_report's handlers.
- Cleans up some direct accesses to the configuration dictionaries (bad practice)
- Removes some no longer used code
- Fixes two old, easily missed bugs. Namely that underscores in the file path caused dm_qc_report to fail to identify the resources and exit with an error and that referencing an undefined study code caused a name error crash due to an undeclared reference to 'logger' inside datman/scan.py
