### PR TITLE
Fix for sites with multiple scanners

### DIFF
--- a/datman/config.py
+++ b/datman/config.py
@@ -346,7 +346,7 @@ class config(object):
         xnat_projects = [site['XNAT_Archive']
                          for site in self.get_key(['Sites']).values()]
 
-        return(xnat_projects)
+        return(list(set(xnat_projects)))
 
     def get_sites(self):
         if not self.study_config:


### PR DESCRIPTION
Sites with multiple scanners in config file return duplicate project IDs