### PR TITLE
Add export and output options to dm_proc_fmri

### DIFF
--- a/bin/dm_proc_fmri.py
+++ b/bin/dm_proc_fmri.py
@@ -316,9 +316,6 @@ def main():
 
     nii_dir = os.path.join(study_base, config.get_path('nii'))
 
-    import pdb
-    pdb.set_trace() 
-    
     if scanid:
         path = os.path.join(nii_dir, scanid)
         if '_PHA_' in scanid:


### PR DESCRIPTION
Make it easier for people wanting to run custom pipelines to output into their own folders with additional options to override config. 