### PR TITLE
Fixed links to wrong session

### DIFF
--- a/bin/dm_link.py
+++ b/bin/dm_link.py
@@ -132,7 +132,8 @@ def main():
     zips_path = cfg.get_path('zips')
 
     if not os.path.isdir(dicom_path):
-        logger.warning('Dicom path {} doesnt exist'.format(dicom_path))
+        logger.warning('Dicom folder {} doesnt exist, creating it.'.format(
+                dicom_path))
         try:
             os.makedirs(dicom_path)
         except IOError:

--- a/bin/dm_link_project_scans.py
+++ b/bin/dm_link_project_scans.py
@@ -179,12 +179,11 @@ def link_files(tags, src_session, trg_session, src_data_dir, trg_data_dir):
                     dm.scanid.parse_filename(filename)
             except dm.scanid.ParseException:
                 continue
-            if file_tag in tags:
-                # need to create the link
-                # first need to capture the file extension as it gets lost
-                # when using dm.scanid to make the new name
-                ext = dm.utils.get_extension(filename)
+            if ident.session == src_session.session and file_tag in tags:
+                # If the file is from the same session we're supposed to link
+                # and the tag is in the list, make a link.
 
+                ext = dm.utils.get_extension(filename)
                 trg_name = dm.scanid.make_filename(trg_session, file_tag,
                                                    series, description)
                 src_file = os.path.join(root, filename)


### PR DESCRIPTION
When a src target had multiple sessions, the target session ended up with links for all scans in all sessions. This PR fixes this for https://github.com/TIGRLab/admin/issues/1622