### PR TITLE
Bug fix to stop killing dm_xnat_extract

### DIFF
--- a/bin/dm_log_server.py
+++ b/bin/dm_log_server.py
@@ -27,7 +27,8 @@ from docopt import docopt
 
 import datman.config
 
-FORMAT = logging.Formatter("[%(name)s] %(levelname)s: %(message)s")
+FORMAT = logging.Formatter("%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        "%H:%M:%S")
 LOG_DIR = None
 
 class LogRecordStreamHandler(SocketServer.StreamRequestHandler):

--- a/datman/dashboard.py
+++ b/datman/dashboard.py
@@ -180,7 +180,12 @@ def add_session(name, date=None):
     new_session = timepoint.add_session(sess_num, date=date)
 
     if timepoint.expects_redcap():
-        monitors.monitor_redcap_import(str(timepoint), sess_num)
+        try:
+            monitors.monitor_redcap_import(str(timepoint), sess_num)
+        except dashboard.monitors.MonitorException as e:
+            logger.error("Could not add scheduled check for redcap scan "
+                    "completed survey for {}. Reason: {}".format(str(timepoint),
+                    str(e)))
 
     return new_session
 

--- a/datman/dashboard.py
+++ b/datman/dashboard.py
@@ -182,7 +182,7 @@ def add_session(name, date=None):
     if timepoint.expects_redcap():
         try:
             monitors.monitor_redcap_import(str(timepoint), sess_num)
-        except dashboard.monitors.MonitorException as e:
+        except monitors.MonitorException as e:
             logger.error("Could not add scheduled check for redcap scan "
                     "completed survey for {}. Reason: {}".format(str(timepoint),
                     str(e)))


### PR DESCRIPTION
The uncaught exception was tanking dm_xnat_extract when it tried to pull down studies that didnt yet have at least one QCer assigned in the database. Whoops.