### PR TITLE
Json standards

### DIFF
--- a/bin/dm_bids_app.py
+++ b/bin/dm_bids_app.py
@@ -17,8 +17,8 @@ Options:
     -q, --quiet                     Only display ERROR Messages
     -v, --verbose                   Display INFO/WARNING/ERROR Messages
     -d, --debug                     Display DEBUG/INFO/WARNING/ERROR Messages
-    -r, --rewrite                   Overwrite if outputs already exist in BIDS output directory 
-    -t, --tmp-dir TMPDIR            Specify temporary directory 
+    -r, --rewrite                   Overwrite if outputs already exist in BIDS output directory
+    -t, --tmp-dir TMPDIR            Specify temporary directory
                                     [default : '/tmp/']
     -b, --bids-dir BIDSDIR          Specify BIDS directory to use
                                     [default : 'TMPDIR/bids']
@@ -104,8 +104,8 @@ def get_bids_name(subject):
 
         try:
             ident = scan_ident.parse(subject + '_01')
-        except scan_ident.ParseException: 
-            logger.error('{s} and {s}_01, is invalid!'.format(s=subject)) 
+        except scan_ident.ParseException:
+            logger.error('{s} and {s}_01, is invalid!'.format(s=subject))
             raise
 
     return ident.get_bids_name()
@@ -161,25 +161,25 @@ def filter_subjects(subjects,out_dir,bids_app):
         bids_app                Name of BIDS-app (all upper-case convention)
     '''
 
-    #Base log directory 
+    #Base log directory
     log_dir = os.path.join(out_dir,'bids_logs',bids_app.lower())
     log_file = os.path.join(log_dir,'{}_{}.log')
-    run_list = [] 
+    run_list = []
 
     #Use error keyword to identify subjects needing to be re-run
-    for s in subjects: 
+    for s in subjects:
 
         try:
-            if 'error' in open(log_file.format(s,bids_app)).read().lower(): 
-                run_list.append(s) 
+            if 'error' in open(log_file.format(s,bids_app)).read().lower():
+                run_list.append(s)
                 logger.debug('Re-running {} through {}, error found!'.format(s,bids_app))
-        except IOError: 
+        except IOError:
             logger.debug('Running new subject {} through {}'.format(s,bids_app))
-            run_list.append(s) 
-        
+            run_list.append(s)
+
     return run_list
 
-    
+
 
 def get_json_args(json_file):
     '''
@@ -226,10 +226,10 @@ def validate_json_args(jargs,test_dict):
         logger.error('BIDS-app {} not supported!'.format(jargs['app']))
         raise
     else:
-        #Enforce application name will always be in upper case 
-        jargs['app'] = jargs['app'].upper() 
+        #Enforce application name will always be in upper case
+        jargs['app'] = jargs['app'].upper()
 
-    
+
     return jargs
 
 def get_exclusion_cmd(exclude):
@@ -298,7 +298,7 @@ def get_init_cmd(study,sgroup,bids_dir,tmp_dir,out_dir,simg,log_tag):
             simg=simg,
             sub=get_bids_name(sgroup).replace('sub-',''),
             out=out_dir,
-            log_tag=log_tag.replace('&>>','&>')) 
+            log_tag=log_tag.replace('&>>','&>'))
     #The log replace bit is to ensure that logs are wiped prior to appending for easier error tracking on re-runs
 
     return [trap_cmd,init_cmd]
@@ -586,13 +586,13 @@ def submit_jobfile(job_file,subject,queue,walltime='24:00:00',threads=1):
     '''
 
     if queue == 'slurm':
-        thread_arg = '--job-name {subject} --cpus-per-task {threads} --time {wtime}'.format(subject=subject, 
+        thread_arg = '--job-name {subject} --cpus-per-task {threads} --time {wtime}'.format(subject=subject,
                 threads=threads,wtime=walltime)
         cmd = 'sbatch {args} '.format(args=thread_arg)
 
     else:
         thread_arg = '-l nodes=1:ppn={threads},walltime={wtime}'.format(threads=threads,wtime=walltime) \
-                if queue =='pbs' else '' 
+                if queue =='pbs' else ''
         cmd = 'qsub {pbs} -V -N {subject}'.format(pbs=thread_arg,subject=subject)
 
     #Append job to cmd
@@ -743,7 +743,7 @@ def main():
     jargs = validate_json_args(jargs,strat_dict)
     try:
         jargs.update({'keeprecon' : config.get_key('KeepRecon')})
-    except KeyError:
+    except datman.config.UndefinedSetting:
         jargs.update({'keeprecon':True})
     n_thread = get_requested_threads(jargs,thread_dict)
 

--- a/bin/dm_bids_app.py
+++ b/bin/dm_bids_app.py
@@ -137,9 +137,9 @@ def get_datman_config(study):
 
     try:
         config = datman.config.config(study=study)
-    except KeyError:
-        logger.error('{} not a valid study ID!'.format(study))
-        sys.exit(1)
+    except Exception as e:
+        logger.error('Failed to retrieve configuration. Reason: {}'.format(e))
+        raise e
 
     if study != config.study_name:
         logger.error('Study incorrectly entered as subject {}, please fix arguments!'.format(study))
@@ -733,10 +733,11 @@ def main():
     config = get_datman_config(study)
     configure_logger(quiet,verbose,debug)
     try:
-        queue = config.site_config['SystemSettings'][os.environ['DM_SYSTEM']]['QUEUE']
-    except KeyError as e:
-        logger.error('Config exception, key not found: {}'.format(e))
-        sys.exit(1)
+        queue = config.get_key('QUEUE')
+    except Exception as e:
+        logger.error("Couldnt retrieve queue type from config. Reason: "
+                "{}".format(e))
+        raise e
 
     #JSON parsing, formatting, and validating
     jargs = get_json_args(bids_json)

--- a/bin/dm_header_checks.py
+++ b/bin/dm_header_checks.py
@@ -58,8 +58,6 @@ def main():
     # Will add later
     # update_database(series_json, diffs)
 
-# def run all without main (for use in other scripts)
-
 def parse_file(file_path):
     try:
         with open(file_path, "r") as fh:

--- a/bin/dm_header_checks.py
+++ b/bin/dm_header_checks.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+"""
+Usage:
+    dm_header_checks.py [options] [--ignore=<STR>]... <series> <standard>
+
+Arguments:
+    <series>                Full path to the series JSON file being examined
+    <standard>              Full path to the standards JSON file to compare
+                            against
+
+Options:
+    --output <PATH>         Full path to store output as a file
+    --ignore <STR>          A dicom header field to ignore. Can be specified
+                            more than once.
+    --ignore-file <PATH>    Full path to a text file of header fields to ignore
+                            with each field name on a new line
+    --tolerance <PATH>      Full path to a json file mapping field names to a
+                            tolerance for that field
+    --ignore-db             Disable attempts to update database
+"""
+import json
+
+from numpy import isclose
+from docopt import docopt
+
+def main():
+    args = docopt(__doc__)
+    series_json = args['<series>']
+    standard_json = args['<standard>']
+    output = args['--output']
+    ignored_fields = args['--ignore']
+    tolerances = args['--tolerance']
+    ignore_db = args['--ignore-db']
+
+    series = read_json(series_json)
+    standard = read_json(standard_json)
+    if tolerances:
+        tolerances = read_json(tolerances)
+
+    diffs = compare_headers(series, standard, ignore=ignored_fields,
+            tolerance=tolerances)
+
+    if output:
+        write_diff_log(diffs, output)
+
+    # if ignore_db:
+    #     return
+    #
+    # update_database(series_json, diffs)
+
+# def run all without main!!!
+
+def read_json(json_file):
+    with open(json_file, "r") as fp:
+        contents = json.load(fp)
+    return contents
+
+def compare_headers(series, standard, ignore=None, tolerance=None):
+    if ignore:
+        remove_fields(standard, ignore)
+    if not tolerance:
+        tolerance = {}
+
+    diffs = {}
+    for field in standard:
+        try:
+            value = series[field]
+        except KeyError:
+            diffs.setdefault('missing', []).append(field)
+        if value != standard[field]:
+            result = handle_diff(value, standard[field], tolerance.get(field))
+            if result:
+                diffs[field] = result
+    return diffs
+
+def remove_fields(json_contents, fields):
+    for item in fields:
+        try:
+            del json_contents[item]
+        except KeyError:
+            pass
+
+def handle_diff(value, expected, tolerance=None):
+    diffs = {'expected': expected, 'actual': value}
+
+    if not tolerance:
+        return diffs
+
+    if isclose(value, expected, atol=tolerance):
+        return {}
+
+    diffs['tolerance'] = tolerance
+    return diffs
+
+def write_diff_log(diffs, output_path):
+    if not diffs:
+        return
+    with open(output_path, 'w') as dest:
+        json.dump(diffs, dest)
+
+# def update_database(series, diffs):
+#     return
+
+if __name__ == "__main__":
+    main()

--- a/bin/dm_header_checks.py
+++ b/bin/dm_header_checks.py
@@ -103,6 +103,7 @@ def compare_headers(series, standard, ignore=None, tolerance=None):
             value = series[field]
         except KeyError:
             diffs.setdefault('missing', []).append(field)
+            continue
         if value != standard[field]:
             result = handle_diff(value, standard[field], tolerance.get(field))
             if result:

--- a/bin/dm_link_shared_ids.py
+++ b/bin/dm_link_shared_ids.py
@@ -144,7 +144,7 @@ def get_redcap_token(config, redcap_cred):
 def link_shared_ids(config, connection, record):
     try:
         xnat_archive = config.get_key('XNAT_Archive', site=record.id.site)
-    except KeyError:
+    except datman.config.UndefinedSetting:
         logger.error("Can't find XNAT_Archive for subject {}".format(record.id))
         return
     project = connection.select.project(xnat_archive)

--- a/bin/dm_proc_freesurfer.py
+++ b/bin/dm_proc_freesurfer.py
@@ -323,14 +323,14 @@ def update_aggregate_log(config, qc_subjects, destination):
 def update_aggregate_stats(config):
     logger.info("Updating aggregate stats")
     freesurfer_dir = config.get_path('freesurfer')
-    enigma_ctx = os.path.join(config.system_config['DATMAN_ASSETSDIR'],
+    enigma_ctx = os.path.join(config.get_key('DATMAN_ASSETSDIR'),
             'ENGIMA_ExtractCortical.sh')
-    enigma_sub = os.path.join(config.system_config['DATMAN_ASSETSDIR'],
+    enigma_sub = os.path.join(config.get_key('DATMAN_ASSETSDIR'),
             'ENGIMA_ExtractSubcortical.sh')
     utils.run('{} {} {}'.format(enigma_ctx, freesurfer_dir,
-            config.study_config['STUDY_TAG']), dryrun=DRYRUN)
+            config.get_key('STUDY_TAG')), dryrun=DRYRUN)
     utils.run('{} {} {}'.format(enigma_sub, freesurfer_dir,
-            config.study_config['STUDY_TAG']), dryrun=DRYRUN)
+            config.get_key('STUDY_TAG')), dryrun=DRYRUN)
 
 def get_blacklist(qc_subjects, scanid):
     # This function is here as bug prevention: If a subject ID is given that

--- a/bin/dm_proc_maget_brain.py
+++ b/bin/dm_proc_maget_brain.py
@@ -354,7 +354,7 @@ class MagetConfig(object):
 
     def __get_datman_atlases(self):
         try:
-            atlas_dir = self.config.system_config['ATLASES']
+            atlas_dir = self.config.get_key('ATLASES')
         except KeyError:
             logger.critical("Cannot find path to atlases for current system.")
             sys.exit(1)

--- a/bin/dm_proc_maget_brain.py
+++ b/bin/dm_proc_maget_brain.py
@@ -367,7 +367,7 @@ class MagetConfig(object):
     def __get_maget_settings(self):
         try:
             maget_config_dict = self.config.get_key('magetbrain')
-        except KeyError:
+        except datman.config.UndefinedSetting:
             logger.critical("Magetbrain configuration not defined for study: {}"
                             "".format(self.config.study_name))
             sys.exit(1)

--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -717,6 +717,30 @@ def find_expected_files(subject, config):
     expected_files = expected_files.sort_values('Sequence')
     return(expected_files)
 
+def get_header_tolerances(config, site):
+    try:
+        defaults = config.get_key("HeaderFieldTolerance", defaults_only=True)
+    except:
+        defaults = {}
+    try:
+        study_settings = config.get_key("HeaderFieldTolerance",
+                ignore_defaults=True)
+    except:
+        study_settings = {}
+    try:
+        site_settings = config.get_key("HeaderFieldTolerance", site=site)
+    except:
+        site_settings = {}
+
+    for key in site_settings:
+        # Override any tolerances with same name in the study defaults
+        study_settings[key] = site_settings[key]
+    for key in study_settings:
+        # Override any site wide defaults with the study or site specific settings
+        defaults[key] = study_settings[key]
+
+    return defaults
+
 def get_ignored_header_fields(config, site):
     try:
         site_fields = config.get_key("IgnoreHeaderFields", site=site)
@@ -779,6 +803,7 @@ def run_header_qc(subject, log_file, config):
     tag_settings = config.get_tags(site=subject.site)
 
     ignored_fields = get_ignored_header_fields(config, subject.site)
+    header_tolerances = get_header_tolerances(config, subject.site)
 
     header_diffs = {}
     for series in subject.niftis:

--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -789,8 +789,14 @@ def run_header_qc(subject, config):
     standards_dict = get_standards(standard_dir, subject.site)
     tag_settings = config.get_tags(site=subject.site)
 
-    ignored_headers = config.get_key('IgnoreHeaderFields', site=subject.site)
-    header_tolerances = config.get_key('HeaderFieldTolerance', site=subject.site)
+    try:
+        ignored_headers = config.get_key('IgnoreHeaderFields', site=subject.site)
+    except datman.config.UndefinedSetting:
+        ignored_headers = []
+    try:
+        header_tolerances = config.get_key('HeaderFieldTolerance', site=subject.site)
+    except datman.config.UndefinedSetting:
+        header_tolerances = {}
 
     header_diffs = {}
     for series in subject.niftis:

--- a/bin/dm_redcap_scan_completed.py
+++ b/bin/dm_redcap_scan_completed.py
@@ -67,7 +67,7 @@ def get_version(api_url, token):
 
 def add_session_redcap(record):
     record_id = record['record_id']
-    subject_id = record[cfg.get_key(['REDCAP_SUBJ'])].upper()
+    subject_id = record[cfg.get_key('REDCAP_SUBJ')].upper()
     if not datman.scanid.is_scanid(subject_id):
         try:
             subject_id = subject_id + '_01'
@@ -81,7 +81,7 @@ def add_session_redcap(record):
         logger.error('Invalid session: {}, skipping'.format(subject_id))
         return
 
-    session_date = record[cfg.get_key(['REDCAP_DATE'])]
+    session_date = record[cfg.get_key('REDCAP_DATE')]
 
     try:
         session = dashboard.get_session(ident, date=session_date, create=True)
@@ -92,8 +92,8 @@ def add_session_redcap(record):
     try:
         session.add_redcap(record_id, redcap_project, redcap_url, instrument,
                 date=session_date,
-                comment=record[cfg.get_key(['REDCAP_COMMENTS'])],
-                event_id=cfg.get_key(['REDCAP_EVENTID'])[record['redcap_event_name']],
+                comment=record[cfg.get_key('REDCAP_COMMENTS')],
+                event_id=cfg.get_key('REDCAP_EVENTID')[record['redcap_event_name']],
                 version=redcap_version)
     except:
         logger.error('Failed adding REDCap info for session {} to dashboard'.format(ident))
@@ -141,14 +141,14 @@ def main():
     dir_meta = cfg.get_path('meta')
 
     # configure redcap variables
-    api_url = cfg.get_key(['REDCAP_URL'])
+    api_url = cfg.get_key('REDCAP_URL')
     redcap_url = api_url.replace('/api/', '/')
 
-    token_path = os.path.join(dir_meta, cfg.get_key(['REDCAP_TOKEN']))
+    token_path = os.path.join(dir_meta, cfg.get_key('REDCAP_TOKEN'))
     token = read_token(token_path)
 
-    redcap_project = cfg.get_key(['REDCAP_PROJECTID'])
-    instrument = cfg.get_key(['REDCAP_INSTRUMENT'])
+    redcap_project = cfg.get_key('REDCAP_PROJECTID')
+    instrument = cfg.get_key('REDCAP_INSTRUMENT')
 
     redcap_version = get_version(api_url, token)
 
@@ -157,8 +157,8 @@ def main():
     project_records = []
     for item in response.json():
         # only grab records where instrument has been marked complete
-        if not (item[cfg.get_key(['REDCAP_DATE'])] and
-                item[cfg.get_key(['REDCAP_STATUS'])] == '1'):
+        if not (item[cfg.get_key('REDCAP_DATE')] and
+                item[cfg.get_key('REDCAP_STATUS')] == '1'):
             continue
         project_records.append(item)
 

--- a/bin/dm_sftp.py
+++ b/bin/dm_sftp.py
@@ -106,7 +106,7 @@ def main():
 def get_server_config(cfg):
     server_config = {}
 
-    default_mrserver = cfg.get_key(['FTPSERVER'])
+    default_mrserver = cfg.get_key('FTPSERVER')
     try:
     	server_config[default_mrserver] = read_config(cfg)
     except KeyError as e:
@@ -116,14 +116,14 @@ def get_server_config(cfg):
     # Sites may override the study defaults. If they dont, the defaults will
     # be returned and should NOT be re-added to the config
     for site in cfg.get_sites():
-        site_server = cfg.get_key(['FTPSERVER'], site=site)
+        site_server = cfg.get_key('FTPSERVER', site=site)
 
         if site_server in server_config:
             continue
 
         try:
             server_config[site_server] = read_config(cfg, site=site)
-        except KeyError as e:	
+        except KeyError as e:
             logger.debug(e.message)
     return server_config
 
@@ -131,19 +131,17 @@ def get_server_config(cfg):
 def read_config(cfg, site=None):
     logger.debug("Getting MR sftp server config for site: {}".format(
             site if site else "default"))
-    try:
-        mrusers = cfg.get_key(['MRUSER'], site=site)
-        mrfolders = cfg.get_key(['MRFOLDER'], site=site)
-    except KeyError:
-        raise KeyError("MRUSER or MRFOLDER is not defined. Skipping.")
+
+    mrusers = cfg.get_key('MRUSER', site=site)
+    mrfolders = cfg.get_key('MRFOLDER', site=site)
 
     try:
         pass_file = cfg.get_key('MRFTPPASS', site=site)
-    except KeyError:
+    except datman.config.UndefinedSetting:
         pass_file = 'mrftppass.txt'
     try:
         server_port = cfg.get_key('FTPPORT', site=site)
-    except KeyError:
+    except datman.config.UndefinedSetting:
         server_port = 22
 
     return (mrusers, mrfolders, pass_file, server_port)

--- a/bin/dm_to_bids.py
+++ b/bin/dm_to_bids.py
@@ -97,7 +97,7 @@ def get_missing_data(data, nii_file):
 
 def to_sub(ident):
 
-    return ident.get_bids_name() 
+    return ident.get_bids_name()
 
 def to_ses(timepoint):
     return "ses-{:02}".format(int(timepoint))
@@ -426,7 +426,7 @@ def init_setup(study, cfg, bids_dir):
     data = dict()
     try:
         data["Name"] = cfg.get_key('FullName')
-    except KeyError:
+    except config.UndefinedSetting:
         data["Name"] = study
     data["BIDSVersion"] = "1.0.2"
 
@@ -510,7 +510,7 @@ def main():
 
     #Run if either queue disabled or single subject
     else:
-        for sub_id in sub_ids: 
+        for sub_id in sub_ids:
             subject_dir = sub_id
             if scanid.is_phantom(subject_dir):
                 logger.info("File is phantom and will be ignored: {}".format(subject_dir))

--- a/bin/dm_xnat_upload.py
+++ b/bin/dm_xnat_upload.py
@@ -164,7 +164,7 @@ def get_xnat_session(ident):
     """
     # get the expected xnat project name from the config filename
     try:
-        xnat_project = CFG.get_key(['XNAT_Archive'],
+        xnat_project = CFG.get_key('XNAT_Archive',
                                    site=ident.site)
     except:
         logger.warning('Study:{}, Site:{}, xnat archive not defined in config'

--- a/bin/xnat_fetch_sessions.py
+++ b/bin/xnat_fetch_sessions.py
@@ -218,7 +218,7 @@ def get_credentials(credentials_path):
 def add_server_handler(config):
     try:
         server_ip = config.get_key('LOGSERVER')
-    except KeyError:
+    except datman.config.UndefinedSetting:
         raise KeyError("\'LOGSERVER\' not defined in site config file.")
     server_handler = logging.handlers.SocketHandler(server_ip,
             logging.handlers.DEFAULT_TCP_LOGGING_PORT)
@@ -229,7 +229,7 @@ def get_xnat_config(config, site):
         cred_file = config.get_key('XNAT_source_credentials', site=site)
         server = config.get_key('XNAT_source', site=site)
         archive = config.get_key('XNAT_source_archive', site=site)
-    except KeyError:
+    except datman.config.UndefinedSetting:
         raise KeyError("Missing configuration. Please ensure study or site "
                 "configuration defines all needed values: XNAT_source, "
                 "XNAT_source_credentials, XNAT_source_archive. See help string "

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -20,10 +20,7 @@ def get_server(config, url=None, port=None):
         use_port = True
 
     if not url:
-        try:
-            url = config.get_key('XNATSERVER')
-        except KeyError:
-            raise KeyError("'XNATSERVER' not defined in config file")
+        url = config.get_key('XNATSERVER')
 
     # Check for 'http' and NOT https, because checking for https could mangle a
     # url into https://http<restof>


### PR DESCRIPTION
Before pulling into the archive we need to:
   - Add  timepoints.header_diffs to the production database
   - Add a list of header fields to ignore to tigrlab_config.yaml under the key 'IgnoreHeaderFields'
   - Add a dictionary of header fields and their tolerances to tigrlab_config.yaml under 'HeaderFieldTolerance'.  

Still working on the dashboard UI changes to actually use this info, but the QC pages will work as before (I cleaned up the table that presents diffs a bit)