### PR TITLE
Patches

### DIFF
--- a/bin/dm_header_checks.py
+++ b/bin/dm_header_checks.py
@@ -74,6 +74,8 @@ def construct_diffs(series_json, standard_json, ignored_fields=None,
     if dti:
         bval_diffs = check_bvals(series_json, standard_json)
         if bval_diffs:
+            if isinstance(bval_diffs, str):
+                bval_diffs = {'error': bval_diffs}
             diffs['bvals'] = bval_diffs
 
     return diffs

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -300,7 +300,7 @@ def set_date(session, experiment):
     try:
         date = experiment['data_fields']['date']
     except KeyError:
-        logger.error("No scanning date found for {}, leaving blank.".format(
+        logger.debug("No scanning date found for {}, leaving blank.".format(
                 session))
         return
 


### PR DESCRIPTION
Small bug fixes to 1) stop the nightly logs from being spammed with " ERROR - No scanning date found for X" error messages and 2) stop dm_qc_report from crashing completely when a bval file cant be found. The error instead gets written to the qc page.