### PR TITLE
mriqc should run on high-moby

### DIFF
--- a/assets/dm_bids_app_config/mriqc_local.json
+++ b/assets/dm_bids_app_config/mriqc_local.json
@@ -2,7 +2,7 @@
 
 	"app":"MRIQC",
 	"img": "/archive/code/containers/MRIQC/poldracklab_mriqc_0.14.2-2018-08-21-453030cc5a18.img",
-	"partition":"low-moby",
+	"partition":"high-moby",
 
 	"bidsargs":
 	{


### PR DESCRIPTION
temporary fix so low-moby isn't used, since we'll be replacing everything with nextflow pipelines down the line... 

