### PR TITLE
BIDS subject ID should not include sub- field 

### DIFF
--- a/datman/scanid.py
+++ b/datman/scanid.py
@@ -78,7 +78,7 @@ class Identifier:
 
     def get_bids_name(self):
 
-        return 'sub-' + self.site + self.subject
+        return  self.site + self.subject
 
     def get_full_subjectid_with_timepoint(self):
         ident = self.get_full_subjectid()


### PR DESCRIPTION
Changes are done to make it easier to structure BIDS filename construction since the sub component is the field not the ID