### PR TITLE
Add dcm2niix errors to database / file system

### DIFF
--- a/bin/dm_header_checks.py
+++ b/bin/dm_header_checks.py
@@ -23,11 +23,9 @@ Options:
                             as the series (or gold standard) with the
                             same file name as the series (or gold standard)
 """
-import os
-import json
-
-from numpy import isclose
 from docopt import docopt
+
+from datman import header_checks
 
 def main():
     args = docopt(__doc__)
@@ -45,116 +43,14 @@ def main():
     if tolerances:
         tolerances = read_json(tolerances)
 
-    diffs = construct_diffs(series_json, standard_json, ignored_fields,
-            tolerances, dti)
+    diffs = header_checks.construct_diffs(series_json, standard_json,
+            ignored_fields, tolerances, dti)
 
     if not diffs:
         return
 
     if output:
-        write_diff_log(diffs, output)
-
-def parse_file(file_path):
-    try:
-        with open(file_path, "r") as fh:
-            contents = fh.readlines()
-    except Exception as e:
-        raise type(e)("Couldnt read file of field names to ignore. "
-                "{}".format(str(e)))
-    return [line.strip() for line in contents]
-
-def construct_diffs(series_json, standard_json, ignored_fields=None,
-            tolerances=None, dti=False):
-    series = read_json(series_json)
-    standard = read_json(standard_json)
-
-    diffs = compare_headers(series, standard, ignore=ignored_fields,
-            tolerance=tolerances)
-
-    if dti:
-        bval_diffs = check_bvals(series_json, standard_json)
-        if bval_diffs:
-            if isinstance(bval_diffs, str):
-                bval_diffs = {'error': bval_diffs}
-            diffs['bvals'] = bval_diffs
-
-    return diffs
-
-def read_json(json_file):
-    with open(json_file, "r") as fp:
-        contents = json.load(fp)
-    return contents
-
-def compare_headers(series, standard, ignore=None, tolerance=None):
-    if ignore:
-        remove_fields(standard, ignore)
-    if not tolerance:
-        tolerance = {}
-
-    diffs = {}
-    for field in standard:
-        try:
-            value = series[field]
-        except KeyError:
-            diffs.setdefault('missing', []).append(field)
-            continue
-        if value != standard[field]:
-            result = handle_diff(value, standard[field], tolerance.get(field))
-            if result:
-                diffs[field] = result
-    return diffs
-
-def remove_fields(json_contents, fields):
-    for item in fields:
-        try:
-            del json_contents[item]
-        except KeyError:
-            pass
-
-def handle_diff(value, expected, tolerance=None):
-    diffs = {'expected': expected, 'actual': value}
-
-    if not tolerance:
-        return diffs
-
-    try:
-        close_enough = isclose(value, expected, atol=tolerance)
-    except ValueError as e:
-        close_enough = False
-
-    if type(close_enough) != bool:
-        if all(close_enough):
-            return {}
-    elif close_enough:
-        return {}
-
-    diffs['tolerance'] = tolerance
-    return diffs
-
-def check_bvals(series_path, standard_path):
-    try:
-        series_bval = find_bvals(series_path)
-        standard_bval = find_bvals(standard_path)
-    except IOError as e:
-        return 'Error - {}'.format(e)
-    if series_bval != standard_bval:
-        return {'expected': standard_bval, 'actual': series_bval}
-    return {}
-
-def find_bvals(json_path):
-    bval_path = json_path.replace('json', 'bval')
-    if not os.path.isfile(bval_path):
-        raise IOError("bval for {} does not exist".format(json_path))
-    try:
-        with open(bval_path, "r") as bval_fh:
-            bvals = bval_fh.readlines()[0]
-    except:
-        raise IOError("Unable to read bval file {}".format(bval_path))
-    return bvals
-
-def write_diff_log(diffs, output_path):
-    with open(output_path, 'w') as dest:
-        json.dump(diffs, dest)
+        header_checks.write_diff_log(diffs, output)
 
 if __name__ == "__main__":
     main()

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -811,7 +811,7 @@ def export_nii_command(seriesdir, outputdir, stem, multiecho=False):
     # convert into tempdir
     with datman.utils.make_temp_directory(prefix="dm_xnat_extract_") as tmpdir:
         datman.utils.run('dcm2niix -z y -b y -o {} {}'
-                         .format(tmpdir, seriesdir), DRYRUN)
+                        .format(tmpdir, seriesdir), DRYRUN)
         # move nii and accompanying files (BIDS, dirs, etc) from tmpdir/ to nii/
         for f in glob('{}/*'.format(tmpdir)):
             bn = os.path.basename(f)

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -844,7 +844,30 @@ def export_nii_command(seriesdir, outputdir, stem, multiecho=False):
                 logger.debug("Moving dcm2niix output {} to {} has failed"
                              .format(f, outputdir))
                 continue
+        if dashboard.dash_found:
+            update_side_cars(outputdir, stem)
 
+def update_side_cars(output_dir, stem):
+    side_cars = glob(os.path.join(output_dir, stem + '*.json'))
+    if not side_cars:
+        logger.error("No JSONs found for {} couldn't update dashboard".format(
+                stem))
+        return
+    if len(side_cars) > 1:
+        logger.error("More than one JSON found for {}, could not update "
+                "dashboard".format(stem))
+        return
+    try:
+        scan = dashboard.get_scan(stem)
+    except Exception as e:
+        logger.error("Failed to retrieve dashboard record for {}. "
+                "Reason - {}".format(stem, e))
+        return
+    try:
+        scan.add_json(side_cars[0])
+    except Exception as e:
+        logger.error("Failed to add JSON side car to dashboard record "
+                "for {}. Reason - {}".format(side_cars[0], e))
 
 def export_nrrd_command(seriesdir, outputdir, stem, multiecho=False):
     """Converts a DICOM series to NRRD format"""

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -852,14 +852,14 @@ def export_nii_command(seriesdir, outputdir, stem, multiecho=False):
 
 def get_scan_db_record(scan_name):
     try:
-        scan = dashboard.get_scan(stem)
+        scan = dashboard.get_scan(scan_name)
     except Exception as e:
         logger.error("Failed to retrieve dashboard record for {}. "
-                     "Reason - {}".format(stem, e))
+                     "Reason - {}".format(scan_name, e))
         return None
     return scan
 
-def update_side_cars(output_dir, stem, scan):
+def update_side_cars(output_dir, stem):
     side_cars = glob(os.path.join(output_dir, stem + '*.json'))
     if not side_cars:
         logger.error("No JSONs found for {} couldn't update dashboard".format(
@@ -878,7 +878,7 @@ def update_side_cars(output_dir, stem, scan):
         logger.error("Failed to add JSON side car to dashboard record "
                      "for {}. Reason - {}".format(side_cars[0], e))
 
-def report_issues(dest, stem, messages):
+def report_issues(dest, messages):
     # The only issue we care about currently is if files are missing
     if 'missing images' not in messages:
         return
@@ -889,7 +889,7 @@ def report_issues(dest, stem, messages):
         logger.error("Failed writing dcm2niix conversion errors to {}. Reason "
                      "- {} {}".format(dest, type(e).__name__, e))
     if dashboard.dash_found:
-        scan = get_scan_db_record(os.path.splitext(os.path.basename(stem))[0])
+        scan = get_scan_db_record(os.path.splitext(os.path.basename(dest))[0])
     if not scan:
         return
     scan.add_error(messages)

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -810,8 +810,8 @@ def export_nii_command(seriesdir, outputdir, stem, multiecho=False):
 
     # convert into tempdir
     with datman.utils.make_temp_directory(prefix="dm_xnat_extract_") as tmpdir:
-        datman.utils.run('dcm2niix -z y -b y -o {} {}'
-                        .format(tmpdir, seriesdir), DRYRUN)
+        _, log_msgs = datman.utils.run('dcm2niix -z y -b y -o {} {}'
+                                       .format(tmpdir, seriesdir), DRYRUN)
         # move nii and accompanying files (BIDS, dirs, etc) from tmpdir/ to nii/
         for f in glob('{}/*'.format(tmpdir)):
             bn = os.path.basename(f)
@@ -844,30 +844,55 @@ def export_nii_command(seriesdir, outputdir, stem, multiecho=False):
                 logger.debug("Moving dcm2niix output {} to {} has failed"
                              .format(f, outputdir))
                 continue
+            error_log = os.path.join(outputdir, stem) + '.err'
+            report_issues(error_log, log_msgs)
+
         if dashboard.dash_found:
             update_side_cars(outputdir, stem)
 
-def update_side_cars(output_dir, stem):
-    side_cars = glob(os.path.join(output_dir, stem + '*.json'))
-    if not side_cars:
-        logger.error("No JSONs found for {} couldn't update dashboard".format(
-                stem))
-        return
-    if len(side_cars) > 1:
-        logger.error("More than one JSON found for {}, could not update "
-                "dashboard".format(stem))
-        return
+def get_scan_db_record(scan_name):
     try:
         scan = dashboard.get_scan(stem)
     except Exception as e:
         logger.error("Failed to retrieve dashboard record for {}. "
-                "Reason - {}".format(stem, e))
+                     "Reason - {}".format(stem, e))
+        return None
+    return scan
+
+def update_side_cars(output_dir, stem, scan):
+    side_cars = glob(os.path.join(output_dir, stem + '*.json'))
+    if not side_cars:
+        logger.error("No JSONs found for {} couldn't update dashboard".format(
+                     stem))
+        return
+    if len(side_cars) > 1:
+        logger.error("More than one JSON found for {}, could not update "
+                     "dashboard".format(stem))
+        return
+    scan = get_scan_db_record(stem)
+    if not scan:
         return
     try:
         scan.add_json(side_cars[0])
     except Exception as e:
         logger.error("Failed to add JSON side car to dashboard record "
-                "for {}. Reason - {}".format(side_cars[0], e))
+                     "for {}. Reason - {}".format(side_cars[0], e))
+
+def report_issues(dest, stem, messages):
+    # The only issue we care about currently is if files are missing
+    if 'missing images' not in messages:
+        return
+    try:
+        with open(dest, "w") as output:
+            output.write(messages)
+    except Exception as e:
+        logger.error("Failed writing dcm2niix conversion errors to {}. Reason "
+                     "- {} {}".format(dest, type(e).__name__, e))
+    if dashboard.dash_found:
+        scan = get_scan_db_record(os.path.splitext(os.path.basename(stem))[0])
+    if not scan:
+        return
+    scan.add_error(messages)
 
 def export_nrrd_command(seriesdir, outputdir, stem, multiecho=False):
     """Converts a DICOM series to NRRD format"""

--- a/datman/header_checks.py
+++ b/datman/header_checks.py
@@ -1,0 +1,110 @@
+"""
+Utility functions for comparing nifti json header files to json gold standard
+files.
+"""
+import os
+import json
+
+from numpy import isclose
+
+def parse_file(file_path):
+    try:
+        with open(file_path, "r") as fh:
+            contents = fh.readlines()
+    except Exception as e:
+        raise type(e)("Couldnt read file of field names to ignore. "
+                "{}".format(str(e)))
+    return [line.strip() for line in contents]
+
+def construct_diffs(series_json, standard_json, ignored_fields=None,
+            tolerances=None, dti=False):
+    series = read_json(series_json)
+    standard = read_json(standard_json)
+
+    diffs = compare_headers(series, standard, ignore=ignored_fields,
+            tolerance=tolerances)
+
+    if dti:
+        diffs['bvals'] = check_bvals(series_json, standard_json)
+
+    return diffs
+
+def read_json(json_file):
+    with open(json_file, "r") as fp:
+        contents = json.load(fp)
+    return contents
+
+def compare_headers(series, standard, ignore=None, tolerance=None):
+    if not series or not standard:
+        raise Exception("Must provide JSON contents for series and gold "
+                "standard")
+
+    if ignore:
+        remove_fields(standard, ignore)
+    if not tolerance:
+        tolerance = {}
+
+    diffs = {}
+    for field in standard:
+        try:
+            value = series[field]
+        except KeyError:
+            diffs.setdefault('missing', []).append(field)
+            continue
+        if value != standard[field]:
+            result = handle_diff(value, standard[field], tolerance.get(field))
+            if result:
+                diffs[field] = result
+    return diffs
+
+def remove_fields(json_contents, fields):
+    for item in fields:
+        try:
+            del json_contents[item]
+        except KeyError:
+            pass
+
+def handle_diff(value, expected, tolerance=None):
+    diffs = {'expected': expected, 'actual': value}
+
+    if not tolerance:
+        return diffs
+
+    try:
+        close_enough = isclose(value, expected, atol=tolerance)
+    except ValueError as e:
+        close_enough = False
+
+    if type(close_enough) != bool:
+        if all(close_enough):
+            return {}
+    elif close_enough:
+        return {}
+
+    diffs['tolerance'] = tolerance
+    return diffs
+
+def check_bvals(series_path, standard_path):
+    try:
+        series_bval = find_bvals(series_path)
+        standard_bval = find_bvals(standard_path)
+    except IOError as e:
+        return {'error': '{}'.format(e)}
+    if series_bval != standard_bval:
+        return {'expected': standard_bval, 'actual': series_bval}
+    return {}
+
+def find_bvals(json_path):
+    bval_path = json_path.replace('json', 'bval')
+    if not os.path.isfile(bval_path):
+        raise IOError("bval for {} does not exist".format(json_path))
+    try:
+        with open(bval_path, "r") as bval_fh:
+            bvals = bval_fh.readlines()[0]
+    except:
+        raise IOError("Unable to read bval file {}".format(bval_path))
+    return bvals
+
+def write_diff_log(diffs, output_path):
+    with open(output_path, 'w') as dest:
+        json.dump(diffs, dest)

--- a/datman/scan.py
+++ b/datman/scan.py
@@ -70,6 +70,7 @@ class DatmanNamed(object):
         ident:      A datman.scanid.Identifier instance
     """
     def __init__(self, ident):
+        self._ident = ident
         self.full_id = ident.get_full_subjectid_with_timepoint()
         self.id_plus_session = ident.get_full_subjectid_with_timepoint_session()
         self.study = ident.study


### PR DESCRIPTION
If dcm2niix complains about possibly missing images a text file with the error message gets made and the message gets pushed to the database for later display by the dashboard. This pull request depends on my other one RE: gold standards, so most of the changes can be ignored (sorry)