### PR TITLE
Moar patches! (and some refactoring)

### DIFF
--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -804,6 +804,7 @@ def run_header_qc(subject, config):
             return
         for series in db_session.scans:
             if not series.active_gold_standard:
+                header_diffs[scan_name] = {'error': 'Gold standard not found'}
                 continue
             check_bvals = needs_bval_check(tag_settings, series)
             if not series.json_contents:

--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -804,7 +804,7 @@ def run_header_qc(subject, config):
             return
         for series in db_session.scans:
             if not series.active_gold_standard:
-                header_diffs[scan_name] = {'error': 'Gold standard not found'}
+                header_diffs[series.name] = {'error': 'Gold standard not found'}
                 continue
 
             if not series.json_contents:

--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -807,7 +807,8 @@ def run_header_qc(subject, config):
                 continue
             check_bvals = needs_bval_check(tag_settings, series)
             if not series.json_contents:
-                logger.error("No JSON found for {}".format(series))
+                logger.debug("No JSON found for {}".format(series))
+                header_diffs[series.name] = {'error': 'JSON not found'}
                 continue
             db_diffs = series.update_header_diffs(ignore=ignored_headers,
                     tolerance=header_tolerances, bvals=check_bvals)

--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -806,14 +806,17 @@ def run_header_qc(subject, config):
             if not series.active_gold_standard:
                 header_diffs[scan_name] = {'error': 'Gold standard not found'}
                 continue
-            check_bvals = needs_bval_check(tag_settings, series)
+
             if not series.json_contents:
                 logger.debug("No JSON found for {}".format(series))
                 header_diffs[series.name] = {'error': 'JSON not found'}
                 continue
+
+            check_bvals = needs_bval_check(tag_settings, series)
             db_diffs = series.update_header_diffs(ignore=ignored_headers,
                     tolerance=header_tolerances, bvals=check_bvals)
             header_diffs[series.name] = db_diffs.diffs
+
         return header_diffs
 
     standard_dir = config.get_path('std')

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -11,13 +11,16 @@ Arguments:
     <session>          Fullname of the session to process
 
 Options:
-    --blacklist FILE         Table listing series to ignore override the default metadata/blacklist.csv
+    --blacklist FILE         Table listing series to ignore override the default
+                             metadata/blacklist.csv
     -v --verbose             Show intermediate steps
     -d --debug               Show debug messages
     -q --quiet               Show minimal output
     -n --dry-run             Do nothing
-    --server URL             XNAT server to connect to, overrides the server defined in the site config file.
-    -u --username USER       XNAT username. If specified then the credentials file is ignored and you are prompted for password.
+    --server URL             XNAT server to connect to, overrides the server
+                             defined in the site config file.
+    -u --username USER       XNAT username. If specified then the credentials
+                             file is ignored and you are prompted for password.
     --dont-update-dashboard  Dont update the dashboard database
     -t --tag tag,...         List of scan tags to download
 
@@ -130,8 +133,7 @@ def main():
 
     if session:
         datman.utils.validate_subject_id(session, cfg)
-        # if session has been provided on the command line, identify which
-        # xnat project it is in
+        # identify which xnat project the session is in
         xnat_project = xnat.find_session(session, xnat_projects)
 
         if not xnat_project:
@@ -149,6 +151,7 @@ def main():
 
     for session in sessions:
         process_session(session)
+
 
 def configure_logging(study, quiet=None, verbose=None, debug=None):
     ch = logging.StreamHandler(sys.stdout)
@@ -172,6 +175,8 @@ def configure_logging(study, quiet=None, verbose=None, debug=None):
     logger.addHandler(ch)
     logging.getLogger('datman.utils').addHandler(ch)
     logging.getLogger('datman.dashboard').addHandler(ch)
+    logging.getLogger('datman.xnat').addHandler(ch)
+
 
 def collect_sessions(xnat_projects, config):
     sessions = []
@@ -215,23 +220,13 @@ def process_session(session):
         return
 
     try:
-        experiment_label = get_experiment_label(xnat_project, session_label)
+        xnat_session = xnat.get_session(xnat_project, session_label)
     except Exception as e:
-        logger.error("Can't process session {}. {}{}".format(session_label,
-                type(e), e))
+        logger.error("Cant process session {}. {}{}".format(session_label,
+                     type(e), e))
         return
 
-    # retrieve json table from project --> session --> experiment
-    try:
-        experiment = xnat.get_experiment(xnat_project,
-                                         session_label,
-                                         experiment_label)
-    except Exception as e:
-        logger.error("Failed getting experiment for session: {} with reason"
-                     .format(session_label, e))
-        return
-
-    if not experiment:
+    if not xnat_session.experiment:
         logger.warning("No experiments found for session: {}"
                        .format(session_label))
         return
@@ -244,51 +239,12 @@ def process_session(session):
             logger.error("Failed adding session {}. Reason: {}".format(
                     session_label, e))
         else:
-            set_date(db_session, experiment)
+            set_date(db_session, xnat_session.experiment)
 
-    # experiment['children'] is a list of top level folders in XNAT
-    # project --> session --> experiments
-    for data in experiment['children']:
-        if data['field'] == 'resources/resource':
-            process_resources(xnat_project, session_label, experiment_label,
-                              data)
-        elif data['field'] == 'scans/scan':
-            process_scans(ident, xnat_project, session_label, experiment_label,
-                          data)
-        else:
-            logger.warning("Unrecognised field type {} for experiment {} "
-                           "in session {} from study {}"
-                           .format(data['field'],
-                                   experiment_label,
-                                   session_label,
-                                   xnat_project))
-
-
-def get_experiment_label(xnat_project, session_label):
-    try:
-        experiments = xnat.get_experiments(xnat_project, session_label)
-    except Exception as e:
-        raise datman.exceptions.XnatException("Failed getting experiments for "
-                "{} in project {}. Reason: {}".format(session_label,
-                xnat_project, e))
-
-    if len(experiments) > 1:
-        raise datman.exceptions.XnatException("Found more than one experiment "
-                "for session {} in study {}. ".format(session_label,
-                xnat_project))
-
-    if not experiments:
-        raise datman.exceptions.XnatException("Session {} in study {} has no "
-                "experiments".format(session_label, xnat_project))
-
-    experiment_label = experiments[0]['label']
-
-    if not experiment_label == session_label:
-        logger.warning("Experiment label {} doesn't match session label {}"
-                       .format(experiment_label, session_label))
-
-    return experiment_label
-
+    if xnat_session.resource_files:
+        process_resources(xnat_session)
+    if xnat_session.scans:
+        process_scans(ident, xnat_session)
 
 def set_date(session, experiment):
     try:
@@ -311,27 +267,26 @@ def set_date(session, experiment):
     session.date = date
     session.save()
 
-def process_resources(xnat_project, session_label, experiment_label, data):
+def process_resources(xnat_session):
     """Export any non-dicom resources from the XNAT archive"""
     logger.info("Extracting {} resources from {}"
-                .format(len(data), session_label))
+                .format(len(xnat_session.resource_files), xnat_session.name))
+
     base_path = os.path.join(cfg.get_path('resources'),
-                             session_label)
+                             xnat_session.name)
     if not os.path.isdir(base_path):
-        logger.info("Creating resources dir: {}".format(base_path))
+        logger.info("Creating resources dir {}".format(base_path))
         try:
             os.makedirs(base_path)
         except OSError:
-            logger.error("Failed creating resources dir: {}".format(base_path))
+            logger.error("Failed creating resources dir {}".format(base_path))
             return
 
-    for item in data['items']:
-        try:
-            data_type = item['data_fields']['label']
-        except KeyError:
-            data_type = 'MISC'
-
-        target_path = os.path.join(base_path, data_type)
+    for label in xnat_session.resource_IDs:
+        if label == 'No Label':
+            target_path = os.path.join(base_path, 'MISC')
+        else:
+            target_path = os.path.join(base_path, label)
 
         try:
             target_path = datman.utils.define_folder(target_path)
@@ -340,55 +295,54 @@ def process_resources(xnat_project, session_label, experiment_label, data):
                          .format(target_path))
             continue
 
-        xnat_resource_id = item['data_fields']['xnat_abstractresource_id']
+        xnat_resource_id = xnat_session.resource_IDs[label]
 
         try:
-            resources = xnat.get_resource_list(xnat_project,
-                                               session_label,
-                                               experiment_label,
+            resources = xnat.get_resource_list(xnat_session.project,
+                                               xnat_session.name,
+                                               xnat_session.experiment_label,
                                                xnat_resource_id)
-            if not resources:
-                continue
         except Exception as e:
-            logger.error("Failed getting resource: {} "
-                         "for session: {} in project: {}"
-                         .format(xnat_resource_id, session_label, e))
+            logger.error("Failed getting resource {} for session {}. "
+                         "Reason - {}".format(xnat_resource_id,
+                         xnat_session.name, e))
+            continue
+
+        if not resources:
             continue
 
         for resource in resources:
             resource_path = os.path.join(target_path, resource['URI'])
             if os.path.isfile(resource_path):
-                logger.debug("Resource: {} found for session: {}"
-                             .format(resource['name'], session_label))
+                logger.debug("Resource {} found for session {}"
+                             .format(resource['name'], xnat_session.name))
 
             else:
                 logger.info("Resource: {} not found for session: {}"
-                        .format(resource['name'], session_label))
-                get_resource(xnat_project,
-                             session_label,
-                             experiment_label,
-                             xnat_resource_id,
-                             resource['URI'],
-                             resource_path)
+                        .format(resource['name'], xnat_session.name))
+                download_resource(xnat_session,
+                                  xnat_resource_id,
+                                  resource['URI'],
+                                  resource_path)
 
 
-def get_resource(xnat_project, xnat_session, xnat_experiment,
-                 xnat_resource_id, xnat_resource_uri, target_path):
+def download_resource(xnat_session, xnat_resource_id, xnat_resource_uri,
+                      target_path):
     """
     Download a single resource file from XNAT. Target path should be
     full path to store the file, including filename
     """
 
     try:
-        source = xnat.get_resource(xnat_project,
-                                   xnat_session,
-                                   xnat_experiment,
+        source = xnat.get_resource(xnat_session.project,
+                                   xnat_session.name,
+                                   xnat_session.experiment_label,
                                    xnat_resource_id,
                                    xnat_resource_uri,
                                    zipped=False)
     except Exception as e:
-        logger.error("Failed downloading resource archive from: {} with "
-                     "reason: {}".format(xnat_session, e))
+        logger.error("Failed downloading resource archive from {} with "
+                     "reason: {}".format(xnat_session.name, e))
         return
 
     # check that the target path exists
@@ -405,26 +359,25 @@ def get_resource(xnat_project, xnat_session, xnat_experiment,
         if not DRYRUN:
             shutil.copyfile(source, target_path)
     except:
-        logger.error("Failed copying resource: {} to target: {}"
+        logger.error("Failed copying resource {} to target {}"
                      .format(source, target_path))
 
     # finally delete the temporary archive
     try:
         os.remove(source)
     except OSError:
-        logger.error("Failed to remove temporary archive: {} on system: {}"
+        logger.error("Failed to remove temporary archive {} on system {}"
                      .format(source, platform.node()))
-    return(target_path)
+    return target_path
 
 
-def process_scans(ident, xnat_project, session_label, experiment_label, scans):
+def process_scans(ident, xnat_session):
     """
     Process a set of scans in an XNAT experiment
     scanid is a valid datman.scanid object
-    Scans is the json output from XNAT query representing scans
-    in an experiment
+    xnat_session is an instance of datman.xnat.Session
     """
-    logger.info("Processing scans in session {}".format(session_label))
+    logger.info("Processing scans in session {}".format(xnat_session.name))
 
     # load the export info from the site config files
     tags = cfg.get_tags(site=ident.site)
@@ -434,47 +387,53 @@ def process_scans(ident, xnat_project, session_label, experiment_label, scans):
                      .format(cfg.study_name, ident.site))
         return
 
-    for scan in scans['items']:
-        series_id = scan['data_fields']['ID']
+    for scan in xnat_session.scans:
 
-        if not raw_dicoms_exist(scan):
+        if not scan.raw_dicoms_exist():
             logger.warning("Skipping series {} for session {}. No RAW dicoms "
-                           "exist".format(series_id, session_label))
+                           "exist".format(scan.series, xnat_session.name))
             continue
 
-        if is_derived(scan):
+        if scan.is_derived():
             logger.warning("Series {} in session {} is a derived scan. "
-                           "Skipping.".format(series_id, session_label))
+                           "Skipping.".format(scan.series, xnat_session.name))
             continue
 
-        file_stem, tag, multiecho = create_scan_name(tags.series_map,
-                                                     scan,
-                                                     session_label)
-        if not file_stem:
+        if not scan.description:
+            logger.error("Can't find description for series {} "
+                         "from session {}"
+                         .format(scan.series, xnat_session.name))
             continue
 
-        if multiecho:
-            for stem, t in zip(file_stem, tag):
-                if wanted_tags and (t not in wanted_tags):
-                    continue
-                export_formats = get_export_formats(ident, stem, tags, t)
-                if export_formats:
-                    get_scans(ident, xnat_project, session_label, experiment_label,
-                              series_id, export_formats, file_stem, multiecho)
+        try:
+            scan.set_datman_name(tags.series_map)
+        except Exception as e:
+            logger.error("Failed to make file name for series {} in session "
+                         "{}. Reason {}: {}".format(scan.series,
+                                                  xnat_session.name,
+                                                  type(e),
+                                                  e))
             continue
 
-        file_stem = file_stem[0]
-        tag = tag[0]
-        if wanted_tags and (tag not in wanted_tags):
+        if len(scan.tags) > 1 and not scan.multiecho:
+            logger.error("Multiple export patterns match for {}, "
+                         "descr: {}, tags: {}".format(xnat_session.name,
+                                                      scan.description,
+                                                      scan.tags))
             continue
-        export_formats = get_export_formats(ident, file_stem, tags, tag)
-        if export_formats:
-            get_scans(ident, xnat_project, session_label, experiment_label,
-                      series_id, export_formats, file_stem, multiecho)
 
+        if not db_ignore:
+            update_dashboard(scan.names)
 
-def get_export_formats(ident, file_stem, tags, tag):
-    if not db_ignore:
+        for fname, tag in zip(scan.names, scan.tags):
+            if wanted_tags and (tag not in wanted_tags):
+                continue
+            export_formats = get_export_formats(ident, fname, tags, tag)
+            if export_formats:
+                get_scans(ident, scan, fname, export_formats)
+
+def update_dashboard(scan_names):
+    for file_stem in scan_names:
         logger.info("Adding scan {} to dashboard".format(file_stem))
         try:
             dashboard.get_scan(file_stem, create=True)
@@ -482,6 +441,8 @@ def get_export_formats(ident, file_stem, tags, tag):
             logger.error("Failed adding scan {} to dashboard with "
                     "error: {}".format(file_stem, e))
 
+
+def get_export_formats(ident, file_stem, tags, tag):
     try:
         blacklist_entry = datman.utils.read_blacklist(scan=file_stem, config=cfg)
     except datman.scanid.ParseException:
@@ -502,133 +463,11 @@ def get_export_formats(ident, file_stem, tags, tag):
 
     export_formats = series_is_processed(ident, file_stem, export_formats)
     if not export_formats:
-        logger.warn("Scan: {} has been processed. Skipping"
+        logger.debug("Scan: {} has been processed. Skipping"
                     .format(file_stem))
         return
 
     return export_formats
-
-
-def create_scan_name(series_map, scan_info, session_label):
-    """Creates name suitable for a scan including the tags"""
-    try:
-        series_id = scan_info['data_fields']['ID']
-    except TypeError as e:
-        logger.error("{} failed. Cause: {}".format(session_label, e.message))
-
-    # try and get the scan description, this isn't always in the correct field
-    if 'series_description' in scan_info['data_fields'].keys():
-        description = scan_info['data_fields']['series_description']
-    elif 'type' in scan_info['data_fields'].keys():
-        description = scan_info['data_fields']['type']
-    else:
-        logger.error("Failed to get description for series: {} "
-                     "from session: {}"
-                     .format(series_id, session_label))
-        return None, None, None
-
-    mangled_descr = mangle(description)
-    padded_series = series_id.zfill(2)
-
-    multiecho = is_multiecho(scan_info)
-
-    tag = guess_tag(series_map, scan_info, description, multiecho)
-
-    if not tag:
-        logger.warning("No matching export pattern for {}, "
-                       "descr: {}. Skipping".format(session_label,
-                                                    description))
-        return None, None, None
-    elif len(tag) > 1 and not multiecho:
-        logger.error("Multiple export patterns match for {}, "
-                     "descr: {}, tags: {}".format(session_label,
-                                                  description, tag))
-        return None, None, None
-
-    file_stem = ['_'.join([session_label, t, padded_series, mangled_descr])
-                 for t in tag]
-
-    return file_stem, tag, multiecho
-
-
-def mangle(string):
-    """Mangles a string to conform with the naming scheme.
-
-    Mangling is roughly: convert runs of non-alphanumeric characters to a dash.
-
-    Does not convert '.' to avoid accidentally mangling extensions and does
-    not convert '+'
-    """
-    if not string:
-        string = ""
-    return re.sub(r"[^a-zA-Z0-9.+]+","-",string)
-
-
-def is_multiecho(scan_info):
-    name = scan_info['children'][0]['items'][0]['data_fields'].get('name')
-    if name and 'MultiEcho' in name:
-        return True
-    return False
-
-
-def guess_tag(exportinfo, scan_info, description, multiecho):
-    matches = []
-    for tag, p in exportinfo.iteritems():
-        description_regex = p['SeriesDescription']
-        if isinstance(description_regex, list):
-            description_regex = '|'.join(description_regex)
-        if re.search(description_regex, description, re.IGNORECASE):
-            matches.append(tag)
-
-    if len(matches) == 1:
-        return matches
-    elif len(matches) == 2 and multiecho:
-        return matches
-
-    return guess_fmap_tag(exportinfo, scan_info, multiecho, matches)
-
-
-def guess_fmap_tag(exportinfo, scan_info, multiecho, matches):
-    # field maps might require more information like image type
-    # to distinguish between magnitude, phase and phasediff scans
-    try:
-        image_type = scan_info['data_fields']['parameters/imageType']
-        for tag, p in exportinfo.iteritems():
-            if tag in matches:
-                if not re.search(p['ImageType'], image_type):
-                    matches.remove(tag)
-    except:
-        return None
-
-    if len(matches) == 1:
-        return matches
-    elif len(matches) == 2 and multiecho:
-        return matches
-    return None
-
-
-def raw_dicoms_exist(scan_info):
-    # check if the series contains valid dicom files
-    # this is to exclude the secondary dicoms generated by some scanners
-    # check if RAW (indicating DICOM) is a file type, if not skip
-    for scan_info_child in scan_info['children']:
-        for scan_info_child_item in scan_info_child['items']:
-            if 'content' in scan_info_child_item['data_fields']:
-                file_type = scan_info_child_item['data_fields']['content']
-                if file_type == 'RAW':
-                    return True
-    return False
-
-
-def is_derived(scan_info):
-    try:
-        image_type = scan_info['data_fields']['parameters/imageType']
-    except:
-        logger.warning("Image type could not be found. Assuming it's derived.")
-        return True
-    if 'DERIVED' in image_type:
-        return True
-    return False
 
 
 def series_is_processed(ident, file_stem, export_formats):
@@ -646,8 +485,7 @@ def series_is_processed(ident, file_stem, export_formats):
     return remaining_formats
 
 
-def get_scans(ident, xnat_project, session_label, experiment_label, series_id,
-              export_formats, file_stem, multiecho):
+def get_scans(ident, xnat_scan, output_name, export_formats):
     logger.info("Getting scan from XNAT")
 
     # setup the export functions for each format
@@ -658,13 +496,11 @@ def get_scans(ident, xnat_project, session_label, experiment_label, series_id,
 
     # scan hasn't been completely processed, get it from XNAT
     with datman.utils.make_temp_directory(prefix='dm_xnat_extract_') as temp_dir:
-        src_dir = get_dicom_archive_from_xnat(xnat_project, session_label,
-                                              experiment_label, series_id,
-                                              temp_dir)
+        src_dir = get_dicom_archive_from_xnat(xnat_scan, temp_dir)
 
         if not src_dir:
             logger.error("Failed getting series {} for session {} from XNAT"
-                         .format(series_id, session_label))
+                         .format(xnat_scan.series, xnat_scan.session))
             return
 
         for export_format in export_formats:
@@ -684,20 +520,20 @@ def get_scans(ident, xnat_project, session_label, experiment_label, series_id,
                 logger.error("Export format {} not defined".format(
                              export_format))
 
-            logger.info('Exporting scan {} to format {}'.format(file_stem,
+            logger.info('Exporting scan {} to format {}'.format(xnat_scan.names,
                                                                 export_format))
             try:
-                exporter(src_dir, target_dir, file_stem, multiecho)
+                exporter(src_dir, target_dir, output_name, xnat_scan)
             except:
                 logger.error("An error happened exporting {} from scan: {} "
-                             "in session: {}".format(export_format, series_id,
-                                                     session_label))
+                             "in session: {}".format(export_format,
+                                                     xnat_scan.series,
+                                                     xnat_scan.session))
 
     logger.info('Completed exports')
 
 
-def get_dicom_archive_from_xnat(xnat_project, session_label, experiment_label,
-                                series, tempdir):
+def get_dicom_archive_from_xnat(xnat_scan, tempdir):
     """
     Downloads and extracts a dicom archive from XNAT to a local temp folder
     Returns the path to the tempdir (for later cleanup) as well as the
@@ -705,15 +541,15 @@ def get_dicom_archive_from_xnat(xnat_project, session_label, experiment_label,
     """
     # make a copy of the dicom files in a local directory
     logger.info("Downloading dicoms for: {}, series: {}"
-                .format(session_label, series))
+                .format(xnat_scan.session, xnat_scan.series))
     try:
-        dicom_archive = xnat.get_dicom(xnat_project,
-                                       session_label,
-                                       experiment_label,
-                                       series)
+        dicom_archive = xnat.get_dicom(xnat_scan.project,
+                                       xnat_scan.session,
+                                       xnat_scan.experiment,
+                                       xnat_scan.series)
     except Exception as e:
         logger.error("Failed to download dicom archive for: {}, series: {}"
-                     .format(session_label, series))
+                     .format(xnat_scan.session, xnat_scan.series))
         return None
 
     logger.info("Unpacking archive")
@@ -723,7 +559,7 @@ def get_dicom_archive_from_xnat(xnat_project, session_label, experiment_label,
             myzip.extractall(tempdir)
     except:
         logger.error("An error occurred unpacking dicom archive for: {}. Skipping"
-                     .format(session_label))
+                     .format(xnat_scan.session))
         os.remove(dicom_archive)
         return None
 
@@ -742,7 +578,7 @@ def get_dicom_archive_from_xnat(xnat_project, session_label, experiment_label,
         base_dir = os.path.dirname(archive_files[0])
     except IndexError:
         logger.warning("There were no valid dicom files in XNAT session: {}, series: {}"
-                       .format(session_label, series))
+                       .format(xnat_scan.session, xnat_scan.series))
         return None
     return base_dir
 
@@ -757,7 +593,7 @@ def is_valid_dicom(filename):
     return True
 
 
-def export_mnc_command(seriesdir, outputdir, stem, multiecho=False):
+def export_mnc_command(seriesdir, outputdir, stem, scan=None):
     """Converts a DICOM series to MINC format"""
     outputfile = os.path.join(outputdir, stem) + '.mnc'
 
@@ -779,16 +615,14 @@ def export_mnc_command(seriesdir, outputdir, stem, multiecho=False):
     datman.utils.run(cmd, DRYRUN)
 
 
-def export_nii_command(seriesdir, outputdir, stem, multiecho=False):
+def export_nii_command(seriesdir, outputdir, stem, scan=None):
     """Converts a DICOM series to NifTi format"""
     try:
         check_create_dir(outputdir)
     except:
         return
-    logger.info("Exporting series {}".format(seriesdir))
 
-    if multiecho:
-        echo_dict = get_echo_dict(stem)
+    logger.info("Exporting series {}".format(seriesdir))
 
     # convert into tempdir
     with datman.utils.make_temp_directory(prefix="dm_xnat_extract_") as tmpdir:
@@ -805,10 +639,10 @@ def export_nii_command(seriesdir, outputdir, stem, multiecho=False):
                 logger.error("Unable to parse file {} using the regex".format(bn))
                 continue
 
-            if multiecho:
+            if scan and scan.multiecho:
                 try:
                     echo = int(m.group(4).split('e')[-1][0])
-                    stem = echo_dict[echo]
+                    stem = scan.echo_dict[echo]
                 except:
                     logger.error("Unable to parse valid echo number from file {}"
                                  .format(bn))
@@ -822,23 +656,15 @@ def export_nii_command(seriesdir, outputdir, stem, multiecho=False):
 
             return_code, _ = datman.utils.run("mv {} {}"
                                               .format(f, outputfile), DRYRUN)
-            if ext == '.json' and dashboard.dash_found:
-                update_side_cars(outputfile)
             if return_code:
                 logger.debug("Moving dcm2niix output {} to {} has failed"
                              .format(f, outputdir))
                 continue
+            if ext == '.json' and dashboard.dash_found:
+                update_side_cars(outputfile)
             error_log = os.path.join(outputdir, stem) + '.err'
             report_issues(error_log, log_msgs)
 
-def get_scan_db_record(scan_name):
-    try:
-        scan = dashboard.get_scan(scan_name)
-    except Exception as e:
-        logger.error("Failed to retrieve dashboard record for {}. "
-                     "Reason - {}".format(scan_name, e))
-        return None
-    return scan
 
 def update_side_cars(side_car):
     scan = get_scan_db_record(side_car)
@@ -849,6 +675,17 @@ def update_side_cars(side_car):
     except Exception as e:
         logger.error("Failed to add JSON side car to dashboard record "
                      "for {}. Reason - {}".format(side_car, e))
+
+
+def get_scan_db_record(scan_name):
+    try:
+        scan = dashboard.get_scan(scan_name)
+    except Exception as e:
+        logger.error("Failed to retrieve dashboard record for {}. "
+                     "Reason - {}".format(scan_name, e))
+        return None
+    return scan
+
 
 def report_issues(dest, messages):
     # The only issue we care about currently is if files are missing
@@ -866,7 +703,8 @@ def report_issues(dest, messages):
         return
     scan.add_error(messages)
 
-def export_nrrd_command(seriesdir, outputdir, stem, multiecho=False):
+
+def export_nrrd_command(seriesdir, outputdir, stem, scan=None):
     """Converts a DICOM series to NRRD format"""
     outputfile = os.path.join(outputdir, stem) + '.nrrd'
     try:
@@ -886,7 +724,7 @@ def export_nrrd_command(seriesdir, outputdir, stem, multiecho=False):
     datman.utils.run(cmd, DRYRUN)
 
 
-def export_dcm_command(seriesdir, outputdir, stem, multiecho=False):
+def export_dcm_command(seriesdir, outputdir, stem, scan=None):
     """Copies a DICOM for each echo number in a scan series."""
     try:
         check_create_dir(outputdir)
@@ -895,9 +733,7 @@ def export_dcm_command(seriesdir, outputdir, stem, multiecho=False):
 
     logger.info("Exporting series {}".format(seriesdir))
 
-    if multiecho:
-        echo_dict = get_echo_dict(stem)
-
+    if scan and scan.multiecho:
         dcm_dict = {}
         for path in glob(seriesdir + '/*'):
             try:
@@ -918,9 +754,9 @@ def export_dcm_command(seriesdir, outputdir, stem, multiecho=False):
             except dicom.filereader.InvalidDicomError as e:
                 pass
 
-    if multiecho:
-        for echo_num, dcm_echo_num in zip(echo_dict.keys(), dcm_dict.keys()):
-            outputfile = os.path.join(outputdir, echo_dict[echo_num]) + '.dcm'
+    if scan and scan.multiecho:
+        for echo_num, dcm_echo_num in zip(scan.echo_dict.keys(), dcm_dict.keys()):
+            outputfile = os.path.join(outputdir, scan.echo_dict[echo_num]) + '.dcm'
             if os.path.exists(outputfile):
                 logger.error("Output file {} already exists. Skipping"
                              .format(outputfile))
@@ -955,25 +791,6 @@ def check_create_dir(target):
         except OSError as e:
             logger.error("Failed creating dir: {}".format(target))
             raise e
-
-
-def get_echo_dict(stem):
-    echo_dict = {}
-    for s in stem:
-        ident, tag = datman.scanid.parse_filename(s)[:2]
-        echo_num = get_echo_number(ident, tag)
-        if echo_num not in echo_dict.keys():
-            echo_dict[echo_num] = s
-    return echo_dict
-
-
-def get_echo_number(ident, tag):
-    tags = cfg.get_tags(site=ident.site)
-    exportinfo = tags.series_map
-    for t, p in exportinfo.iteritems():
-        if t == tag:
-            echo_number = p['EchoNumber']
-    return echo_number
 
 
 if __name__ == '__main__':

--- a/datman/exceptions.py
+++ b/datman/exceptions.py
@@ -18,3 +18,6 @@ class DashboardException(Exception):
 
 class MetadataException(Exception):
     pass
+
+class ExportException(Exception):
+    pass

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -908,7 +908,7 @@ class Session(object):
         xnat_scans = []
         for scan_json in scans[0]:
             xnat_scans.append(XNATScan(self.name, self.experiment_label,
-                                       scan_json))
+                                       self.project, scan_json))
         return xnat_scans
 
     def _get_scan_UIDs(self):
@@ -1057,7 +1057,8 @@ class Session(object):
 
 class XNATScan(object):
 
-    def __init__(self, session_name, experiment_name, scan_json):
+    def __init__(self, session_name, experiment_name, project_name, scan_json):
+        self.project = project_name
         self.session = session_name
         self.experiment = experiment_name
         self.uid = str(scan_json['data_fields']['UID'])
@@ -1093,7 +1094,7 @@ class XNATScan(object):
             logger.warning("Image type could not be found for series {}. "
                            "Assuming it's derived.".format(self.series))
             return True
-        if 'DERIVED' in image_type:
+        if 'DERIVED' in self.image_type:
             return True
         return False
 
@@ -1129,7 +1130,7 @@ class XNATScan(object):
         mangled_descr = self._mangle_descr()
         padded_series = self.series.zfill(2)
         tag_settings = self.set_tag(tag_map)
-        if not tags:
+        if not tag_settings:
             raise ExportException("Can't identify tag for series {}".format(
                                   self.series))
         names = []


### PR DESCRIPTION
This pull request:

1. Stops dm_symlink_scans from complaining when it looks for dicoms and they're missing because they were blacklisted.
2. Fixes the bug I accidentally introduced where dm_qc_report.py would crash when a json was missing or the gold standard wasnt found. The code for generating header diffs with the dashboard now behaves the same as the code for doing it from the file system.
3. Refactors dm_xnat_extract.py a bit to improve readability
4. Fixes a bug in dm_xnat_extract.py where some scans (definitely multi-echo scans but possibly others) werent having jsons added when they got exported because they didnt have a scan entry in the database in time for the call to 'update_side_cars'