### PR TITLE
[FIX] - Decode bytestring for version from redcap

### DIFF
--- a/bin/dm_redcap_scan_completed.py
+++ b/bin/dm_redcap_scan_completed.py
@@ -67,6 +67,12 @@ def get_version(api_url, token):
                'content': 'version'}
     response = requests.post(api_url, data=payload)
     version = response.content
+
+    try:
+        version = version.decode('UTF-8')
+    except AttributeError:
+        pass
+
     return version
 
 


### PR DESCRIPTION
# Issue being fixed
Sometimes, when pulling from REDCAP, python interprets the content as bytestring rather than string. The database doesn't decode this automatically resulting in errors due to character length. This has been an issue for SENDEP for which redcap records have never pulled in correctly because the redcap_version was always read in as a bytestring

# Solution
Run a decode to UTF-8 on the redcap version