### PR TITLE
[FIX] dm_qc_report.py header diff related crashes

### DIFF
--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -398,7 +398,12 @@ def add_header_qc(nifti, qc_html, header_diffs):
 
     # find lines in said log that pertain to the nifti
     scan_name = get_scan_name(nifti)
-    lines = header_diffs[scan_name]
+    try:
+        lines = header_diffs[scan_name]
+    except KeyError:
+        logger.error("Scan name {} missing from generated header diffs."
+                     "".format(scan_name))
+        return
 
     if not lines:
         return

--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -820,11 +820,9 @@ def get_standards(standard_dir, site):
 
 
 def get_scan_name(series):
-    # Allows the dashboard to easily access diffs without needing to know
-    # anything about naming scheme
-    scan_name = series.file_name.replace("_" + series.description, "")\
-            .replace(series.ext, "")
-    return scan_name
+    fname = series.file_name.replace(series.ext, "")
+    dropped_descr = fname.split("_")[:-1]
+    return "_".join(dropped_descr)
 
 
 def needs_bval_check(settings, series):


### PR DESCRIPTION
This fixes two dm_qc_report.py issues:

1. When the tag and series description are identical the file name is mangled in a way that stops header diffs from being found
2. When a scan name can't be found in the header diffs the entire report fails to generate