### PR TITLE
[MAINT/FIX] - Remove nose dependency, fix issues with some tests

### DIFF
--- a/bin/dm_link_shared_ids.py
+++ b/bin/dm_link_shared_ids.py
@@ -41,7 +41,7 @@ import datman.config
 import datman.scanid
 import datman.utils
 
-import dm_link_project_scans as link_scans
+import bin.dm_link_project_scans as link_scans
 import datman.dashboard as dashboard
 from datman.exceptions import InputException
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ test_requires =
     codecov
     coverage
     mock
-    nose
     pytest
 packages = find:
 include_package_data = True

--- a/tests/test_datman_scanid.py
+++ b/tests/test_datman_scanid.py
@@ -1,116 +1,116 @@
 import datman.scanid as scanid
-from nose.tools import eq_, ok_, raises
+import pytest
 
 
-@raises(scanid.ParseException)
 def test_parse_empty():
-    scanid.parse("")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse("")
 
 
-@raises(scanid.ParseException)
 def test_parse_None():
-    scanid.parse(None)
+    with pytest.raises(scanid.ParseException):
+        scanid.parse(None)
 
 
-@raises(scanid.ParseException)
 def test_parse_garbage():
-    scanid.parse("lkjlksjdf")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse("lkjlksjdf")
 
 
 def test_parse_good_scanid():
     ident = scanid.parse("DTI_CMH_H001_01_02")
-    eq_(ident.study, "DTI")
-    eq_(ident.site, "CMH")
-    eq_(ident.subject, "H001")
-    eq_(ident.timepoint, "01")
-    eq_(ident.session, "02")
+    assert ident.study == "DTI"
+    assert ident.site == "CMH"
+    assert ident.subject == "H001"
+    assert ident.timepoint == "01"
+    assert ident.session == "02"
 
 
 def test_scanid_to_string():
     ident = scanid.Identifier("DTI", "CMH", "H001", "01", "02")
-    eq_(str(ident), "DTI_CMH_H001_01_02")
+    assert str(ident) == "DTI_CMH_H001_01_02"
 
 
 def test_is_scanid_garbage():
-    ok_(not scanid.is_scanid("garbage"))
+    assert not scanid.is_scanid("garbage")
 
 
 def test_is_scanid_subjectid_only():
-    ok_(not scanid.is_scanid("DTI_CMH_H001"))
+    assert not scanid.is_scanid("DTI_CMH_H001")
 
 
 def test_is_scanid_extra_fields():
-    eq_(scanid.is_scanid("DTI_CMH_H001_01_01_01_01_01_01"), False)
+    assert scanid.is_scanid("DTI_CMH_H001_01_01_01_01_01_01") is False
 
 
 def test_is_scanid_good():
-    ok_(scanid.is_scanid("SPN01_CMH_0002_01_01"))
+    assert scanid.is_scanid("SPN01_CMH_0002_01_01")
 
 
 def test_get_full_subjectid():
     ident = scanid.parse("DTI_CMH_H001_01_02")
-    eq_(ident.get_full_subjectid(), "DTI_CMH_H001")
+    assert ident.get_full_subjectid() == "DTI_CMH_H001"
 
 
 def test_parse_PHA_scanid():
     ident = scanid.parse("DTI_CMH_PHA_ADN0001")
-    eq_(ident.study, "DTI")
-    eq_(ident.site, "CMH")
-    eq_(ident.subject, "PHA_ADN0001")
-    eq_(ident.timepoint, "")
-    eq_(ident.session, "")
-    eq_(str(ident), "DTI_CMH_PHA_ADN0001")
+    assert ident.study == "DTI"
+    assert ident.site == "CMH"
+    assert ident.subject == "PHA_ADN0001"
+    assert ident.timepoint == ""
+    assert ident.session == ""
+    assert str(ident) == "DTI_CMH_PHA_ADN0001"
 
 
 def test_subject_id_with_timepoint():
     ident = scanid.parse("DTI_CMH_H001_01_02")
-    eq_(ident.get_full_subjectid_with_timepoint(), 'DTI_CMH_H001_01')
+    assert ident.get_full_subjectid_with_timepoint() == 'DTI_CMH_H001_01'
 
 
 def test_PHA_timepoint():
     ident = scanid.parse("DTI_CMH_PHA_ADN0001")
-    eq_(ident.get_full_subjectid_with_timepoint(), 'DTI_CMH_PHA_ADN0001')
+    assert ident.get_full_subjectid_with_timepoint() == 'DTI_CMH_PHA_ADN0001'
 
 
 def test_parse_filename():
     ident, tag, series, description = scanid.parse_filename(
-            'DTI_CMH_H001_01_01_T1_03_description.nii.gz')
-    eq_(str(ident), 'DTI_CMH_H001_01_01')
-    eq_(tag, 'T1')
-    eq_(series, '03')
-    eq_(description, 'description')
+        'DTI_CMH_H001_01_01_T1_03_description.nii.gz')
+    assert str(ident) == 'DTI_CMH_H001_01_01'
+    assert tag == 'T1'
+    assert series == '03'
+    assert description == 'description'
 
 
 def test_parse_filename_PHA():
     ident, tag, series, description = scanid.parse_filename(
-            'DTI_CMH_PHA_ADN0001_T1_02_description.nii.gz')
-    eq_(str(ident), 'DTI_CMH_PHA_ADN0001')
-    eq_(tag, 'T1')
-    eq_(series, '02')
-    eq_(description, 'description')
+        'DTI_CMH_PHA_ADN0001_T1_02_description.nii.gz')
+    assert str(ident) == 'DTI_CMH_PHA_ADN0001'
+    assert tag == 'T1'
+    assert series == '02'
+    assert description == 'description'
 
 
 def test_parse_filename_PHA_2():
     ident, tag, series, description = scanid.parse_filename(
-            'SPN01_MRC_PHA_FBN0013_RST_04_EPI-3x3x4xTR2.nii.gz')
-    eq_(ident.study, 'SPN01')
-    eq_(ident.site, 'MRC')
-    eq_(ident.subject, 'PHA_FBN0013')
-    eq_(ident.timepoint, '')
-    eq_(ident.session, '')
-    eq_(str(ident), 'SPN01_MRC_PHA_FBN0013')
-    eq_(tag, 'RST')
-    eq_(series, '04')
-    eq_(description, 'EPI-3x3x4xTR2')
+        'SPN01_MRC_PHA_FBN0013_RST_04_EPI-3x3x4xTR2.nii.gz')
+    assert ident.study == 'SPN01'
+    assert ident.site == 'MRC'
+    assert ident.subject == 'PHA_FBN0013'
+    assert ident.timepoint == ''
+    assert ident.session == ''
+    assert str(ident) == 'SPN01_MRC_PHA_FBN0013'
+    assert tag == 'RST'
+    assert series == '04'
+    assert description == 'EPI-3x3x4xTR2'
 
 
 def test_parse_filename_with_path():
     ident, tag, series, description = scanid.parse_filename(
-            '/data/DTI_CMH_H001_01_01_T1_02_description.nii.gz')
-    eq_(str(ident), 'DTI_CMH_H001_01_01')
-    eq_(tag, 'T1')
-    eq_(series, '02')
-    eq_(description, 'description')
+        '/data/DTI_CMH_H001_01_01_T1_02_description.nii.gz')
+    assert str(ident) == 'DTI_CMH_H001_01_01'
+    assert tag == 'T1'
+    assert series == '02'
+    assert description == 'description'
 
 
 def test_parse_bids_filename():
@@ -143,73 +143,73 @@ def test_parse_bids_filename_without_run():
     scanid.parse_bids_filename("sub-CMH0001_ses-01_T1w.nii.gz")
 
 
-@raises(scanid.ParseException)
 def test_parse_bids_filename_missing_subject():
-    scanid.parse_bids_filename("ses-01_run-1_T1w")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse_bids_filename("ses-01_run-1_T1w")
 
 
-@raises(scanid.ParseException)
 def test_parse_bids_filename_malformed_subject():
-    scanid.parse_bids_filename("CMH0001_ses-01_run-1_T1w")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse_bids_filename("CMH0001_ses-01_run-1_T1w")
 
 
-@raises(scanid.ParseException)
 def test_parse_bids_filename_missing_session():
-    scanid.parse_bids_filename("sub-CMH0001_run-1_T1w")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse_bids_filename("sub-CMH0001_run-1_T1w")
 
 
-@raises(scanid.ParseException)
 def test_parse_bids_filename_malformed_session():
-    scanid.parse_bids_filename("sub-CMH0001_ses-_run-1_T1w")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse_bids_filename("sub-CMH0001_ses-_run-1_T1w")
 
 
-@raises(scanid.ParseException)
 def test_parse_bids_filename_missing_suffix():
-    scanid.parse_bids_filename("sub-CMH0001_ses-01_run-1.nii.gz")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse_bids_filename("sub-CMH0001_ses-01_run-1.nii.gz")
 
 
-@raises(scanid.ParseException)
 def test_parse_bids_filename_missing_suffix_and_run():
-    scanid.parse_bids_filename("sub-CMH0001_ses-01.nii.gz")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse_bids_filename("sub-CMH0001_ses-01.nii.gz")
 
 
-@raises(scanid.ParseException)
 def test_unknown_entity_does_not_get_set_as_suffix():
-    scanid.parse_bids_filename("sub-CMH_ses-01_new-FIELD_T1w.nii.gz")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse_bids_filename("sub-CMH_ses-01_new-FIELD_T1w.nii.gz")
 
 
-@raises(scanid.ParseException)
 def test_empty_entity_name_does_not_get_set_as_suffix():
-    scanid.parse_bids_filename("sub-CMH_ses-01_-FIELD_T1w.nii.gz")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse_bids_filename("sub-CMH_ses-01_-FIELD_T1w.nii.gz")
 
 
-@raises(scanid.ParseException)
 def test_empty_entity_name_and_label_does_not_get_set_as_suffix():
-    scanid.parse_bids_filename("sub-CMH_ses-01_-_T1w.nii.gz")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse_bids_filename("sub-CMH_ses-01_-_T1w.nii.gz")
 
 
-@raises(scanid.ParseException)
 def test_bids_file_raises_exception_when_wrong_entities_used_for_anat():
-    scanid.parse_bids_filename("sub-CMH0001_ses-01_ce-somefield_dir-somedir"
-                               "_run-1_T1w.nii.gz")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse_bids_filename(
+            "sub-CMH0001_ses-01_ce-somefield_dir-somedir"
+            "_run-1_T1w.nii.gz")
 
 
-@raises(scanid.ParseException)
 def test_bids_file_raises_exception_when_wrong_entities_used_for_task():
-    scanid.parse_bids_filename("sub-CMH0001_ses-01_task-sometask_"
-                               "ce-somefield_run-1_T1w.nii.gz")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse_bids_filename("sub-CMH0001_ses-01_task-sometask_"
+                                   "ce-somefield_run-1_T1w.nii.gz")
 
 
-@raises(scanid.ParseException)
 def test_bids_file_raises_exception_when_wrong_entities_used_for_fmap():
-    scanid.parse_bids_filename("sub-CMH0001_ses-01_dir-somedir_"
-                               "rec-somefield_run-1_T1w.nii.gz")
+    with pytest.raises(scanid.ParseException):
+        scanid.parse_bids_filename("sub-CMH0001_ses-01_dir-somedir_"
+                                   "rec-somefield_run-1_T1w.nii.gz")
 
 
 def test_optional_entities_dont_get_parsed_as_suffix():
     optional_entities = "sub-CMH0001_ses-01_{}_T1w.nii.gz"
-    for entity in ['run', 'acq', 'ce', 'rec', 'echo', 'ce',
-                   'mod', 'task']:
+    for entity in ['run', 'acq', 'ce', 'rec', 'echo', 'ce', 'mod', 'task']:
         optional_field = '{}-11'.format(entity)
         bids_name = optional_entities.format(optional_field)
         parsed = scanid.parse_bids_filename(bids_name)

--- a/tests/test_dm_qc_report.py
+++ b/tests/test_dm_qc_report.py
@@ -249,7 +249,7 @@ class FindTechNotes(unittest.TestCase):
 
     @patch('os.walk', autospec=True)
     def test_first_file_returned_when_multiple_pdfs_but_no_tech_notes(
-        self, mock_walk):
+            self, mock_walk):
         mock_walk.return_value = self.__mock_file_system(randint(1, 10),
                                                          add_notes=False,
                                                          add_pdf=True)

--- a/tests/test_dm_qc_report.py
+++ b/tests/test_dm_qc_report.py
@@ -5,9 +5,8 @@ import logging
 from io import TextIOBase
 from random import randint
 
-import nose.tools
+import pytest
 from mock import patch, call, MagicMock
-
 import datman.config as cfg
 import datman.scan
 import datman.dashboard
@@ -30,26 +29,26 @@ config = cfg.config(filename=site_config_path, system=system, study=study)
 
 
 class GetConfig(unittest.TestCase):
-    @nose.tools.raises(SystemExit)
     def test_exits_gracefully_with_bad_study(self):
-        qc.get_config(study="madeupcode")
+        with pytest.raises(SystemExit):
+            qc.get_config(study="madeupcode")
 
-    @nose.tools.raises(SystemExit)
     @patch('datman.config.config')
-    def test_exits_gracefully_when_paths_missing_from_config(self,
-                                                             mock_config):
-        mock_config.return_value.get_path.side_effect = lambda path: \
+    def test_exits_gracefully_when_paths_missing_from_config(
+            self, mock_config):
+
+        with pytest.raises(SystemExit):
+            mock_config.return_value.get_path.side_effect = lambda path: \
                 {'dcm': '',
                  'nii': ''}[path]
-        qc.get_config("STUDY")
+            qc.get_config("STUDY")
 
 
 class VerifyInputPaths(unittest.TestCase):
-
-    @nose.tools.raises(SystemExit)
     def test_exits_gracefully__with_broken_input_path(self):
         bad_path = ["./fakepath/somewhere"]
-        qc.verify_input_paths(bad_path)
+        with pytest.raises(SystemExit):
+            qc.verify_input_paths(bad_path)
 
     @patch('os.path.exists')
     def test_returns_if_paths_exist(self, mock_exists):
@@ -59,10 +58,9 @@ class VerifyInputPaths(unittest.TestCase):
 
 
 class PrepareScan(unittest.TestCase):
-
-    @nose.tools.raises(SystemExit)
     def test_exits_gracefully_with_bad_subject_id(self):
-        qc.prepare_scan("STUDYSITE_ID", config)
+        with pytest.raises(SystemExit):
+            qc.prepare_scan("STUDYSITE_ID", config)
 
     @patch('bin.dm_qc_report.verify_input_paths')
     @patch('datman.utils')
@@ -106,9 +104,7 @@ class GetStandards(unittest.TestCase):
         T1_standard = 'STUDY_CMH_9999_01_01_T1_02_SagT1.json'
         T1_diff_site = 'STUDY_OTHER_0001_01_01_T1_07_SagT1.json'
 
-        standards = [DTI_standard,
-                     T1_diff_site,
-                     T1_standard]
+        standards = [DTI_standard, T1_diff_site, T1_standard]
         mock_glob.return_value = standards
 
         standard_dict = qc.get_standards(self.path, self.site)
@@ -122,9 +118,11 @@ class GetStandards(unittest.TestCase):
 
     @patch('glob.glob')
     def test_excludes_badly_named_standards(self, mock_glob):
-        standards = ['STUDY_CMH_9999_01_01_DTI60_05_Ax.json',
-                     'STUDY_OTHER_0001_01_01_T1_07_SagT1.json',
-                     'STUDY_CMH_9999_01_01_T102SagT1.json']
+        standards = [
+            'STUDY_CMH_9999_01_01_DTI60_05_Ax.json',
+            'STUDY_OTHER_0001_01_01_T1_07_SagT1.json',
+            'STUDY_CMH_9999_01_01_T102SagT1.json'
+        ]
 
         mock_glob.return_value = standards
 
@@ -141,14 +139,14 @@ class RunHeaderQC(unittest.TestCase):
 
     @patch('bin.dm_qc_report.get_standards')
     @patch('datman.header_checks.construct_diffs')
-    def test_doesnt_crash_with_empty_dicom_dir(self,
-                                               mock_make_diffs,
+    def test_doesnt_crash_with_empty_dicom_dir(self, mock_make_diffs,
                                                mock_standards):
         subject = datman.scan.Scan('STUDY_SITE_ID_01', config)
         assert subject.dicoms == []
 
         mock_standards.return_value = [
-                'STUDY_CMH_0001_01_01_T1_02_SagT1-BRAVO.json']
+            'STUDY_CMH_0001_01_01_T1_02_SagT1-BRAVO.json'
+        ]
 
         qc.run_header_qc(subject, config)
         assert mock_make_diffs.call_count == 0
@@ -156,8 +154,7 @@ class RunHeaderQC(unittest.TestCase):
     @patch('datman.scan.Scan')
     @patch('bin.dm_qc_report.get_standards')
     @patch('datman.header_checks.construct_diffs')
-    def test_doesnt_crash_without_matching_standards(self,
-                                                     mock_make_diffs,
+    def test_doesnt_crash_without_matching_standards(self, mock_make_diffs,
                                                      mock_standards,
                                                      mock_subject):
         dicom1 = datman.scan.Series('STUDY_CMH_9999_01_01_T1_02_Sag.dcm')
@@ -252,8 +249,7 @@ class FindTechNotes(unittest.TestCase):
 
     @patch('os.walk', autospec=True)
     def test_first_file_returned_when_multiple_pdfs_but_no_tech_notes(
-            self,
-            mock_walk):
+        self, mock_walk):
         mock_walk.return_value = self.__mock_file_system(randint(1, 10),
                                                          add_notes=False,
                                                          add_pdf=True)
@@ -272,7 +268,7 @@ class FindTechNotes(unittest.TestCase):
             file_list.append(self.notes)
         for num in range(1, depth + 1):
             cur_path = cur_path + "/dir{}".format(num)
-            dirs = ("dir{}".format(num + 1),)
+            dirs = ("dir{}".format(num + 1), )
             files = ("file1.txt", "file2")
             if num == depth:
                 files = tuple(file_list)

--- a/tests/test_dm_xnat_upload.py
+++ b/tests/test_dm_xnat_upload.py
@@ -2,7 +2,7 @@ import unittest
 import importlib
 import logging
 
-from nose.tools import raises
+import pytest
 from mock import patch, MagicMock
 
 import datman
@@ -23,34 +23,36 @@ class CheckFilesExist(unittest.TestCase):
     session_no_resources = FIXTURE + "xnat_session_missing_resources.txt"
     session_missing_data = FIXTURE + "xnat_session_missing_scan_data.txt"
     archive_scan_uids = [
-            '1.2.840.113619.2.336.4120.8413787.19465.1412083372.445',
-            '1.2.840.113619.2.336.4120.8413787.19465.1412083372.444',
-            '1.2.840.113619.2.336.4120.8413787.19465.1412083372.447',
-            '1.2.840.113619.2.336.4120.8413787.19465.1412083372.446',
-            '1.2.840.113619.2.336.4120.8413787.19465.1412083372.440',
-            '1.2.840.113619.2.80.142631515.25030.1412106144.3.0.2',
-            '1.2.840.113619.2.336.4120.8413787.19465.1412083372.443',
-            '1.2.840.113619.2.336.4120.8413787.19465.1412083372.442',
-            '1.2.840.113619.2.5.18242516414121059301412105930313000',
-            '1.2.840.113619.2.80.142631515.25030.1412106138.1.0.2']
+        '1.2.840.113619.2.336.4120.8413787.19465.1412083372.445',
+        '1.2.840.113619.2.336.4120.8413787.19465.1412083372.444',
+        '1.2.840.113619.2.336.4120.8413787.19465.1412083372.447',
+        '1.2.840.113619.2.336.4120.8413787.19465.1412083372.446',
+        '1.2.840.113619.2.336.4120.8413787.19465.1412083372.440',
+        '1.2.840.113619.2.80.142631515.25030.1412106144.3.0.2',
+        '1.2.840.113619.2.336.4120.8413787.19465.1412083372.443',
+        '1.2.840.113619.2.336.4120.8413787.19465.1412083372.442',
+        '1.2.840.113619.2.5.18242516414121059301412105930313000',
+        '1.2.840.113619.2.80.142631515.25030.1412106138.1.0.2'
+    ]
     archive_experiment_id = '1.2.840.113619.6.336.' \
                             '254801968553430904107911738210738061468'
 
-    @raises(Exception)
-    @patch('bin.dm_xnat_upload.missing_resource_data')
+    @patch('bin.dm_xnat_upload.resource_data_exists')
     @patch('datman.utils.get_archive_headers')
     def test_raises_exception_if_scan_uids_mismatch(self, mock_headers,
-                                                    mock_missing_resources):
+                                                    mock_resources_exist):
         # Set up
         mock_headers.return_value = self.__generate_mock_headers(bad_id=True)
-        mock_missing_resources.return_value = False
+        mock_resources_exist.return_value = True
         xnat_session = self.__get_xnat_session(self.session)
 
         # Run
-        upload.check_files_exist(self.archive, xnat_session, self.ident)
+        data_exists, resources_exist = upload.check_files_exist(
+            self.archive, xnat_session)
 
         # Should raise an exception, so assertion is never reached
-        assert False
+        assert data_exists
+        assert resources_exist
 
     def __generate_mock_headers(self, bad_id=False):
         headers = {}
@@ -68,4 +70,4 @@ class CheckFilesExist(unittest.TestCase):
     def __get_xnat_session(self, text_file):
         with open(text_file, 'r') as session_data:
             xnat_session = eval(session_data.read())
-        return xnat_session
+        return datman.xnat.Session(xnat_session)

--- a/tests/test_dm_xnat_upload.py
+++ b/tests/test_dm_xnat_upload.py
@@ -2,7 +2,6 @@ import unittest
 import importlib
 import logging
 
-import pytest
 from mock import patch, MagicMock
 
 import datman

--- a/tests/test_fs_log_scraper.py
+++ b/tests/test_fs_log_scraper.py
@@ -2,7 +2,7 @@ import unittest
 import logging
 import datetime
 
-from nose.tools import raises
+import pytest
 from mock import patch
 
 import datman.fs_log_scraper as scraper
@@ -18,9 +18,7 @@ class TestFSLog(unittest.TestCase):
     @patch('datman.fs_log_scraper.FSLog.read_log')
     @patch('glob.glob')
     def test_sets_running_status_when_subject_running_less_than_24h(
-                self,
-                mock_glob,
-                mock_read_log):
+            self, mock_glob, mock_read_log):
         mock_glob.return_value = ['/some/path/IsRunning.lh+rh']
         # Time zone isnt taken into account when time is compared, but required
         # by the date parsing code
@@ -34,22 +32,21 @@ class TestFSLog(unittest.TestCase):
     @patch('datman.fs_log_scraper.FSLog.read_log')
     @patch('glob.glob')
     def test_sets_status_timedout_when_subject_running_more_than_24h(
-                self,
-                mock_glob,
-                mock_read_log):
+            self, mock_glob, mock_read_log):
         mock_glob.return_value = ['/some/path/IsRunning.lh+rh']
         two_days_ago = datetime.datetime.now(tz=EST()) - datetime.timedelta(2)
-        mock_read_log.return_value = ['DATE {}'.format(
-                two_days_ago.strftime(self.FS_date_format))]
+        mock_read_log.return_value = [
+            'DATE {}'.format(two_days_ago.strftime(self.FS_date_format))
+        ]
 
         my_log = scraper.FSLog(self.fs_path)
 
         assert my_log.status == scraper.FSLog._TIMEDOUT.format(
-                'IsRunning.lh+rh')
+            'IsRunning.lh+rh')
 
     @patch('glob.glob')
-    def test_sets_status_maybe_halted_when_IsRunning_log_unreadable(self,
-                                                                    mock_glob):
+    def test_sets_status_maybe_halted_when_IsRunning_log_unreadable(
+            self, mock_glob):
         # Return path to nonexistent file
         mock_glob.return_value = ["/some/path/IsRunning.lh+rh"]
 
@@ -77,9 +74,8 @@ class TestFSLog(unittest.TestCase):
 
     @patch('datman.fs_log_scraper.FSLog.read_log')
     @patch('os.path.exists')
-    def test_values_set_to_empty_when_recon_done_unreadable(self,
-                                                            mock_exists,
-                                                            mock_read_log):
+    def test_values_set_to_empty_when_recon_done_unreadable(
+            self, mock_exists, mock_read_log):
         recon_done = self.fs_path + '/scripts/recon-all.done'
         mock_exists.side_effect = lambda x: True if x == recon_done else False
         mock_read_log.return_value = {}
@@ -98,8 +94,8 @@ class TestFSLog(unittest.TestCase):
 
     def test_args_excludes_subject_specific_arguments(self):
         cmd_args = '-all -qcache -notal-check -parallel -subjid SOMEID12345 ' \
-                + '-i /some/path/nii_input1.nii.gz ' \
-                + '-T2 /some/path/nii_input2.nii.gz'
+            + '-i /some/path/nii_input1.nii.gz ' \
+            + '-T2 /some/path/nii_input2.nii.gz'
         relevant_args = ['-all', '-qcache', '-notal-check', '-parallel']
         expected = " ".join(sorted(relevant_args))
 
@@ -109,7 +105,7 @@ class TestFSLog(unittest.TestCase):
 
     def test_args_doesnt_separate_values_associated_with_an_arg(self):
         cmd_args = '-parallel -nuiterations 8 -qcache -subjid SOMEID12345 ' \
-                + '-i /some/path/item1.nii.gz'
+            + '-i /some/path/item1.nii.gz'
         relevant_args = ['-parallel', '-nuiterations 8', '-qcache']
         expected = " ".join(sorted(relevant_args))
 
@@ -137,54 +133,58 @@ class TestFSLog(unittest.TestCase):
 
         nii_inputs = scraper.FSLog.get_niftis(cmd_args)
 
-        for arg in ['-all', '-qcache', '-notal-check', '-nuiterations 8',
-                    '-subjid SOMEID12345']:
+        for arg in [
+                '-all', '-qcache', '-notal-check', '-nuiterations 8',
+                '-subjid SOMEID12345'
+        ]:
             assert arg not in nii_inputs
 
 
 class TestChooseStandardSub(unittest.TestCase):
-
     def test_chooses_subject_without_status_set(self):
         class LogStub(object):
             def __init__(self, subid, status):
                 self.subject = subid
                 self.status = status
+
         subject1 = LogStub('SUBJECT1111', 'Exited')
         subject2 = LogStub('SUBJECT2222', '')
         subject3 = LogStub('SUBJECT3333', 'Still Running')
 
-        standard_sub = scraper.choose_standard_sub([subject1, subject2,
-                                                    subject3])
+        standard_sub = scraper.choose_standard_sub(
+            [subject1, subject2, subject3])
 
         assert standard_sub.subject == subject2.subject
 
-    @raises(Exception)
     def test_raises_exception_if_no_subjects_have_completed_pipeline(self):
         class LogStub(object):
             def __init__(self, subid, status):
                 self.subject = subid
                 self.status = status
+
         subject1 = LogStub('SUBJECT1', 'Exited with error')
         subject2 = LogStub('SUBJECT2', 'Still Running')
 
-        scraper.choose_standard_sub([subject1, subject2])
+        with pytest.raises(Exception):
+            scraper.choose_standard_sub([subject1, subject2])
 
 
 class TestVerifyStandards(unittest.TestCase):
-
-    @raises(KeyError)
     def test_raises_keyerror_when_expected_key_missing(self):
-        standards_dict = {'build': 'expected_build here',
-                          'kernel': 'expected kernel here'}
+        standards_dict = {
+            'build': 'expected_build here',
+            'kernel': 'expected kernel here'
+        }
         expected_keys = ['build', 'kernel', 'args']
 
-        scraper.verify_standards(standards_dict, expected_keys)
-
-        assert False
+        with pytest.raises(KeyError):
+            scraper.verify_standards(standards_dict, expected_keys)
 
     def test_ignores_unexpected_keys(self):
-        standards_dict = {'build': 'build goes here',
-                          'some_key': 'something else goes here'}
+        standards_dict = {
+            'build': 'build goes here',
+            'some_key': 'something else goes here'
+        }
         expected_keys = ['build']
 
         scraper.verify_standards(standards_dict, expected_keys)
@@ -194,7 +194,6 @@ class TestVerifyStandards(unittest.TestCase):
 
 
 class CheckDiff(unittest.TestCase):
-
     def test_no_diffs_returns_empty_string(self):
         log_field = 'kernel1234'
         standard_field = 'kernel1234'
@@ -222,7 +221,6 @@ class CheckDiff(unittest.TestCase):
 
 # A timezone class, to fill in the expected (but not used) datetime timezone
 class EST(datetime.tzinfo):
-
     def utcoffset(self, dt):
         return datetime.timedelta(0)
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 
-from nose.tools import raises
+import pytest
 from mock import patch
 
 import datman.config as cfg
@@ -20,11 +20,10 @@ class TestSeries(unittest.TestCase):
     good_name = "/somepath/STUDY_SITE_9999_01_01_T1_03_SagT1Bravo-09mm.nii.gz"
     bad_name = "/somepath/STUDYSITE_9999_T1_03_SagT1Bravo-09mm.nii.gz"
 
-    @raises(datman.scanid.ParseException)
     def test_raises_parse_exception_with_bad_file_name(self):
-        series = datman.scan.Series(self.bad_name)
 
-        assert series is None
+        with pytest.raises(datman.scanid.ParseException):
+            datman.scan.Series(self.bad_name)
 
     def test_creates_series_for_well_named_file(self):
         series = datman.scan.Series(self.good_name)
@@ -42,9 +41,9 @@ class TestScan(unittest.TestCase):
     phantom = "STUDY_CMH_PHA_ID"
     config = cfg.config(filename=site_config, system=system, study=study)
 
-    @raises(datman.scanid.ParseException)
     def test_raises_parse_exception_with_bad_subject_id(self):
-        datman.scan.Scan(self.bad_name, self.config)
+        with pytest.raises(datman.scanid.ParseException):
+            datman.scan.Scan(self.bad_name, self.config)
 
     def test_makes_scan_instance_for_id_without_session(self):
         subject = datman.scan.Scan(self.good_name, self.config)
@@ -96,7 +95,7 @@ class TestScan(unittest.TestCase):
     def test_niftis_with_either_extension_type_found(self, mock_glob):
         simple_ext = "{}_01_T1_02_SagT1-BRAVO.nii".format(self.good_name)
         complex_ext = "{}_01_DTI60-1000_05_Ax-DTI-60.nii.gz".format(
-                self.good_name)
+            self.good_name)
         wrong_ext = "{}_01_DTI60-1000_05_Ax-DTI-60.bvec".format(self.good_name)
 
         nii_list = [simple_ext, complex_ext, wrong_ext]
@@ -109,20 +108,20 @@ class TestScan(unittest.TestCase):
 
         assert sorted(found_niftis) == sorted(expected)
 
-    @raises(datman.scanid.ParseException)
     @patch('glob.glob')
     def test_subject_series_with_nondatman_name_causes_parse_exception(
             self,
             mock_glob):
         well_named = "{}_01_T1_02_SagT1-BRAVO.nii".format(self.good_name)
         badly_named1 = "{}_01_DTI60-1000_05_Ax-DTI-60.nii".format(
-                self.bad_name)
+            self.bad_name)
         badly_named2 = "{}_01_T2_07.nii".format(self.good_name)
 
         nii_list = [well_named, badly_named1, badly_named2]
         mock_glob.return_value = nii_list
 
-        datman.scan.Scan(self.good_name, self.config)
+        with pytest.raises(datman.scanid.ParseException):
+            datman.scan.Scan(self.good_name, self.config)
 
     @patch('glob.glob')
     def test_dicoms_lists_only_dicom_files(self, mock_glob):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@
 import unittest
 import logging
 
-from nose.tools import raises
+import pytest
 from mock import patch
 
 import datman.utils as utils
@@ -16,23 +16,23 @@ class TestCheckDependencyConfigured(unittest.TestCase):
 
     fake_env = {'PATH': '/some/path', 'FSLDIR': '/path/to/fsl'}
 
-    @raises(EnvironmentError)
     @patch('datman.utils.run')
-    def test_EnvironmentError_raised_if_command_not_found(self, mock_run,
-                                                          mock_env):
+    def test_EnvironmentError_raised_if_command_not_found(
+            self, mock_run, mock_env):
         mock_run.return_value = (0, '')
 
-        utils.check_dependency_configured('FreeSurfer', shell_cmd='recon-all')
+        with pytest.raises(EnvironmentError):
+            utils.check_dependency_configured('FreeSurfer',
+                                              shell_cmd='recon-all')
 
-    @raises(EnvironmentError)
-    def test_EnvironmentError_raised_if_any_env_variable_not_defined(self,
-                                                                     mock_env):
+    def test_EnvironmentError_raised_if_any_env_variable_not_defined(
+            self, mock_env):
         mock_env.__getitem__.side_effect = lambda x: self.fake_env[x]
 
         variables = ['PATH', 'FREESURFER_HOME']
-        utils.check_dependency_configured('MyProgram', env_vars=variables)
 
-        assert False
+        with pytest.raises(EnvironmentError):
+            utils.check_dependency_configured('MyProgram', env_vars=variables)
 
     def test_doesnt_require_list_for_single_env_var(self, mock_env):
         mock_env.__getitem__.side_effect = lambda x: self.fake_env[x]
@@ -42,9 +42,8 @@ class TestCheckDependencyConfigured(unittest.TestCase):
         assert True
 
     @patch('datman.utils.run')
-    def test_exits_successfully_when_command_path_found_and_vars_set(self,
-                                                                     mock_run,
-                                                                     mock_env):
+    def test_exits_successfully_when_command_path_found_and_vars_set(
+            self, mock_run, mock_env):
         mock_env.__getitem__.side_effect = lambda x: self.fake_env[x]
 
         cmd = 'fsl'
@@ -57,6 +56,7 @@ class TestCheckDependencyConfigured(unittest.TestCase):
         mock_run.side_effect = which
         variables = ['FSLDIR']
 
-        utils.check_dependency_configured('FSL', shell_cmd=cmd,
+        utils.check_dependency_configured('FSL',
+                                          shell_cmd=cmd,
                                           env_vars=variables)
         assert True

--- a/tests/test_xnat.py
+++ b/tests/test_xnat.py
@@ -3,7 +3,7 @@ import unittest
 import logging
 
 from mock import Mock, patch
-from nose.tools import raises
+import pytest
 
 import datman.xnat
 # Used only to act as a spec for Mock
@@ -14,19 +14,19 @@ logging.disable(logging.CRITICAL)
 
 
 class TestGetPortStr(unittest.TestCase):
-
     def _set_config_port(self, port):
-        self.mock_config.get_key.side_effect = lambda key: {'XNATPORT': port}[
-                key]
+        self.mock_config.get_key.side_effect = lambda key: {
+            'XNATPORT': port
+        }[key]
 
     def setUp(self):
         self.mock_config = Mock(spec=Config)
         self.mock_config.get_key.side_effect = lambda key: {}[key]
 
-    @raises(KeyError)
     def test_raises_KeyError_when_given_port_is_None_and_config_doesnt_define(
             self):
-        datman.xnat.get_port_str(self.mock_config, None)
+        with pytest.raises(KeyError):
+            datman.xnat.get_port_str(self.mock_config, None)
 
     def test_retrieves_port_from_config_file_when_port_is_None(self):
         expected = ":443"
@@ -72,7 +72,6 @@ class TestGetPortStr(unittest.TestCase):
 
 
 class TestGetServer(unittest.TestCase):
-
     def _set_server_config(self, url, port=None):
         config_dict = {'XNATSERVER': url}
         if port:
@@ -91,8 +90,8 @@ class TestGetServer(unittest.TestCase):
 
         assert returned_server == config_server, ("Returned server {} doesnt "
                                                   "match {}".format(
-                                                        returned_server,
-                                                        config_server))
+                                                      returned_server,
+                                                      config_server))
 
     def test_ignores_config_file_when_given_url(self):
         config_server = 'https://fakeserver.ca'
@@ -104,10 +103,10 @@ class TestGetServer(unittest.TestCase):
 
         assert returned_server != config_server
 
-    @raises(KeyError)
     def test_raises_KeyError_when_server_not_given_and_config_setting_missing(
             self):
-        datman.xnat.get_server(self.mock_config)
+        with pytest.raises(KeyError):
+            datman.xnat.get_server(self.mock_config)
 
     def test_adds_https_protocol_when_no_protocol_in_url(self):
         server = 'someserver.ca'
@@ -167,20 +166,19 @@ class TestGetServer(unittest.TestCase):
 
 
 class TestGetAuth(unittest.TestCase):
-
     @patch('getpass.getpass')
     def test_asks_user_to_enter_password_if_username_provided(self, mock_pass):
         datman.xnat.get_auth('someuser')
         assert mock_pass.call_count == 1
 
-    @raises(KeyError)
     def test_raises_KeyError_if_username_not_given_and_not_set_in_env(self):
-        with patch.dict(os.environ, {}, clear=True):
-            datman.xnat.get_auth()
+        with pytest.raises(KeyError):
+            with patch.dict(os.environ, {}, clear=True):
+                datman.xnat.get_auth()
 
-    @raises(KeyError)
     def test_raises_KeyError_if_username_found_in_env_and_password_not_set(
             self):
         env = {'XNAT_USER': 'someuser'}
-        with patch.dict('os.environ', env, clear=True):
-            datman.xnat.get_auth()
+        with pytest.raises(KeyError):
+            with patch.dict('os.environ', env, clear=True):
+                datman.xnat.get_auth()


### PR DESCRIPTION
# Changes

- All nose dependencies have been removed in favour of pytests
- Fixed bug in test_dm_xnat_upload where test was passing unconditionally 
- Minor added change where dm_link_shared_ids now imports using the base package directory for dm_link_project_scans
