### PR TITLE
[FIX/MAINT] - Only deploy on pypi when commits/PRs are made to the release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,6 @@ workflows:
             - deployable
           filters:
             branches:
-              only: release
+              ignore: /.*/
             tags:
               only: /.*/
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ workflows:
             - test_deploy_pypi
           filters:
             branches:
-              only: release
+              only: master
             tags:
               only: /.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ workflows:
             - test_deploy_pypi
           filters:
             branches:
-              only: master
+              only: release
             tags:
               only: /.*/
 
@@ -179,7 +179,7 @@ workflows:
             - deployable
           filters:
             branches:
-              only: master
+              only: release
             tags:
               only: /.*/
 


### PR DESCRIPTION
Since **Master** will be our in-house production branch which is always being tweaked, we want to reserve deployment for milestones/major bug fixes.

Any commit/PR pushed to the branch **release** will be deployed to pypi.