### PR TITLE
[FIX] Ensure database is available for datman

### DIFF
--- a/datman/dashboard.py
+++ b/datman/dashboard.py
@@ -9,11 +9,12 @@ from datman.exceptions import DashboardException
 logger = logging.getLogger(__name__)
 
 try:
-    from dashboard import queries, monitors
+    from dashboard import queries, monitors, connect_db
 except ImportError:
     dash_found = False
     logger.error("Dashboard not found, proceeding without it.")
 else:
+    connect_db()
     dash_found = True
 
 


### PR DESCRIPTION
The dashboard blueprints refactor in https://github.com/TIGRLab/dashboard/pull/61 means datman needs to operate within an app context. This just makes sure that happens on import. It should be merged in when the blueprints PR is.