### PR TITLE
[ENH] Add KCNI ID support

### DIFF
--- a/bin/dm_link.py
+++ b/bin/dm_link.py
@@ -10,18 +10,18 @@ Usage:
     dm_link.py [options] <study> <zipfile>
 
 Arguments:
-    <study>              Name of the study to process
-    <zipfile>           Single Zipfile to process
+    <study>                 Name of the study to process
+    <zipfile>               Single Zipfile to process
 
 Options:
-    --lookup FILE            Path to scan id lookup table,
-                                overrides metadata/scans.csv
-    --scanid-field STR       Dicom field to match target_name with
-                             [default: PatientName]
-    -v --verbose             Verbose logging
-    -d --debug                  Debug logging
-    -q --quiet             Less debuggering
-    --dry-run             Dry run
+    --lookup FILE           Path to scan id lookup table,
+                            overrides metadata/scans.csv
+    --scanid-field STR      Dicom field to match target_name with
+                            [default: PatientName]
+    -v --verbose            Verbose logging
+    -d --debug              Debug logging
+    -q --quiet              Less debuggering
+    --dry-run               Dry run
 
 
 DETAILS

--- a/bin/dm_link.py
+++ b/bin/dm_link.py
@@ -70,17 +70,21 @@ IGNORING EXAM ARCHIVES
         source_name      target_name            dicom_StudyID
         2014_0126_FB001  <ignore>
 """
-from docopt import docopt
-import sys
-import os
+
 import glob
-import pandas as pd
-import datman.config
-import datman.utils
-import datman.scanid
 import logging
+import os
+import sys
+
+from docopt import docopt
+import pandas as pd
+
+import datman.config
+import datman.scanid
+import datman.utils
 
 logger = logging.getLogger(os.path.basename(__file__))
+
 already_linked = {}
 lookup = None
 DRYRUN = None
@@ -93,14 +97,14 @@ def main():
     global DRYRUN
 
     arguments = docopt(__doc__)
-    verbose = arguments['--verbose']
-    debug = arguments['--debug']
-    DRYRUN = arguments['--dry-run']
-    quiet = arguments['--quiet']
-    study = arguments['<study>']
-    lookup_path = arguments['--lookup']
-    scanid_field = arguments['--scanid-field']
-    zipfile = arguments['<zipfile>']
+    verbose = arguments["--verbose"]
+    debug = arguments["--debug"]
+    DRYRUN = arguments["--dry-run"]
+    quiet = arguments["--quiet"]
+    study = arguments["<study>"]
+    lookup_path = arguments["--lookup"]
+    scanid_field = arguments["--scanid-field"]
+    zipfile = arguments["<zipfile>"]
 
     # setup logging
     ch = logging.StreamHandler(sys.stdout)
@@ -116,8 +120,8 @@ def main():
         logger.setLevel(logging.DEBUG)
         ch.setLevel(logging.DEBUG)
 
-    formatter = logging.Formatter('%(asctime)s - %(name)s - {study} - '
-                                  '%(levelname)s - %(message)s'.format(
+    formatter = logging.Formatter("%(asctime)s - %(name)s - {study} - "
+                                  "%(levelname)s - %(message)s".format(
                                                     study=study))
     ch.setFormatter(formatter)
 
@@ -126,34 +130,34 @@ def main():
     # setup the config object
     cfg = datman.config.config(study=study)
     if not lookup_path:
-        lookup_path = os.path.join(cfg.get_path('meta'), 'scans.csv')
+        lookup_path = os.path.join(cfg.get_path("meta"), "scans.csv")
 
-    dicom_path = cfg.get_path('dicom')
-    zips_path = cfg.get_path('zips')
+    dicom_path = cfg.get_path("dicom")
+    zips_path = cfg.get_path("zips")
 
     if not os.path.isdir(dicom_path):
-        logger.warning('Dicom folder {} doesnt exist, creating it.'.format(
+        logger.warning("Dicom folder {} doesnt exist, creating it.".format(
                 dicom_path))
         try:
             os.makedirs(dicom_path)
         except IOError:
-            logger.error('Failed to create dicom path {}'.format(dicom_path))
+            logger.error("Failed to create dicom path {}".format(dicom_path))
             return
 
     if not os.path.isdir(zips_path):
-        logger.error('Zips path {} doesnt exist'.format(zips_path))
+        logger.error("Zips path {} doesnt exist".format(zips_path))
         return
 
     try:
-        lookup = pd.read_csv(lookup_path, sep='\s+', dtype=str)  # noqa: W605
+        lookup = pd.read_csv(lookup_path, sep="\s+", dtype=str)  # noqa: W605
     except IOError:
-        logger.error('Lookup file {} not found'.format(lookup_path))
+        logger.error("Lookup file {} not found".format(lookup_path))
         return
 
     # identify which zip files have already been linked
     already_linked = {os.path.realpath(f): f
                       for f
-                      in glob.glob(os.path.join(dicom_path, '*'))
+                      in glob.glob(os.path.join(dicom_path, "*"))
                       if os.path.islink(f)}
 
     if zipfile:
@@ -164,16 +168,16 @@ def main():
         archives = [os.path.join(zips_path, archive)
                     for archive
                     in os.listdir(zips_path)
-                    if os.path.splitext(archive)[1] == '.zip']
+                    if os.path.splitext(archive)[1] == ".zip"]
 
-    logger.info('Found {} archives'.format(len(archives)))
+    logger.info("Found {} archives".format(len(archives)))
     for archive in archives:
         link_archive(archive, dicom_path, scanid_field, cfg)
 
 
 def link_archive(archive_path, dicom_path, scanid_field, config):
     if not os.path.isfile(archive_path):
-        logger.error('Archive {} not found'.format(archive_path))
+        logger.error("Archive {} not found".format(archive_path))
         return
 
     try:
@@ -193,33 +197,36 @@ def link_archive(archive_path, dicom_path, scanid_field, config):
     if scanid:
         scanid, lookupinfo = scanid
 
-    if scanid == '<ignore>':
-        logger.info('Ignoring {}'.format(archive_path))
+    if scanid == "<ignore>":
+        logger.info("Ignoring {}".format(archive_path))
         return
 
     if not scanid:
         scanid = get_scanid_from_header(archive_path, scanid_field)
 
     if not scanid:
-        logger.error('Scanid not found for archive: {}'.format(archive_path))
+        logger.error("Scanid not found for archive: {}".format(archive_path))
         return
 
     try:
-        datman.utils.validate_subject_id(scanid, config)
-    except RuntimeError as e:
-        logger.error(str(e) + ". Cannot make link for {}".format(archive_path))
+        ident = datman.utils.validate_subject_id(scanid, config)
+    except datman.scanid.ParseException as e:
+        logger.error("Can't make link for {}. Reason: {}".format(
+            archive_path, e))
         return
+
+    scanid = str(ident)
 
     # do the linking
     target = os.path.join(dicom_path, scanid)
     target = target + datman.utils.get_extension(archive_path)
     if os.path.exists(target):
-        logger.error('Target: {} already exists for archive: {}'
+        logger.error("Target: {} already exists for archive: {}"
                      .format(target, archive_path))
         return
 
     relpath = os.path.relpath(archive_path, dicom_path)
-    logger.info('Linking {} to {}'.format(relpath, target))
+    logger.info("Linking {} to {}".format(relpath, target))
     if not DRYRUN:
         os.symlink(relpath, target)
 
@@ -235,14 +242,14 @@ def get_scanid_from_lookup_table(archive_path):
     global lookup
     basename = os.path.basename(os.path.normpath(archive_path))
     source_name = basename[:-len(datman.utils.get_extension(basename))]
-    lookupinfo = lookup[lookup['source_name'] == source_name]
+    lookupinfo = lookup[lookup["source_name"] == source_name]
 
     if len(lookupinfo) == 0:
         logger.debug("{} not found in source_name column."
                      .format(source_name))
         return
     else:
-        scanid = lookupinfo['target_name'].tolist()[0]
+        scanid = lookupinfo["target_name"].tolist()[0]
         return (scanid, lookupinfo)
 
 
@@ -296,7 +303,7 @@ def validate_headers(archive_path, lookupinfo, scanid_field):
         return False
 
     columns = lookupinfo.columns.values.tolist()
-    dicom_cols = [c for c in columns if c.startswith('dicom_')]
+    dicom_cols = [c for c in columns if c.startswith("dicom_")]
 
     for c in dicom_cols:
         f = c.split("_")[1]
@@ -316,5 +323,5 @@ def validate_headers(archive_path, lookupinfo, scanid_field):
     return True
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/bin/dm_link_project_scans.py
+++ b/bin/dm_link_project_scans.py
@@ -318,7 +318,7 @@ def link_resources(source_id, target_id):
 def get_datman_scanid(session_id, config):
     try:
         session = datman.utils.validate_subject_id(session_id, config)
-    except RuntimeError as e:
+    except datman.scanid.ParseException as e:
         logger.error("Invalid session ID given: {}. Exiting".format(str(e)))
         sys.exit(1)
     return session

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -187,7 +187,7 @@ def collect_subjects(xnat_projects, config):
             try:
                 sub_id = datman.utils.validate_subject_id(subject_id,
                                                           config)
-            except RuntimeError as e:
+            except datman.scanid.ParseException as e:
                 logger.error("Invalid ID {} in project {}. Reason: {}"
                              .format(subject_id, project, str(e)))
                 continue

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -516,8 +516,8 @@ def get_scans(ident, xnat_scan, output_name, export_formats):
         src_dir = get_dicom_archive_from_xnat(xnat_scan, temp)
 
         if not src_dir:
-            logger.error("Failed getting series {} for session {} from XNAT"
-                         .format(xnat_scan.series, xnat_scan.session))
+            logger.error("Failed getting series {} for experiment {} from XNAT"
+                         .format(xnat_scan.series, xnat_scan.experiment))
             return
 
         for export_format in export_formats:
@@ -544,9 +544,9 @@ def get_scans(ident, xnat_scan, output_name, export_formats):
                 exporter(src_dir, target_dir, output_name, xnat_scan)
             except Exception:
                 logger.error("An error happened exporting {} from scan {} "
-                             "in session {}".format(export_format,
-                                                    xnat_scan.series,
-                                                    xnat_scan.session))
+                             "in experiment {}".format(
+                                 export_format, xnat_scan.series,
+                                 xnat_scan.experiment))
 
     logger.info('Completed exports')
 
@@ -559,15 +559,15 @@ def get_dicom_archive_from_xnat(xnat_scan, tempdir):
     """
     # make a copy of the dicom files in a local directory
     logger.info("Downloading dicoms for: {}, series: {}"
-                .format(xnat_scan.session, xnat_scan.series))
+                .format(xnat_scan.experiment, xnat_scan.series))
     try:
         dicom_archive = xnat.get_dicom(xnat_scan.project,
-                                       xnat_scan.session,
+                                       xnat_scan.subject,
                                        xnat_scan.experiment,
                                        xnat_scan.series)
     except Exception:
         logger.error("Failed to download dicom archive for: {}, series: {}"
-                     .format(xnat_scan.session, xnat_scan.series))
+                     .format(xnat_scan.subject, xnat_scan.series))
         return None
 
     logger.info("Unpacking archive")
@@ -577,7 +577,7 @@ def get_dicom_archive_from_xnat(xnat_scan, tempdir):
             myzip.extractall(tempdir)
     except Exception:
         logger.error("An error occurred unpacking dicom archive for: {}. "
-                     "Skipping".format(xnat_scan.session))
+                     "Skipping".format(xnat_scan.subject))
         os.remove(dicom_archive)
         return None
 
@@ -596,7 +596,7 @@ def get_dicom_archive_from_xnat(xnat_scan, tempdir):
         base_dir = os.path.dirname(archive_files[0])
     except IndexError:
         logger.warning("There were no valid dicom files in XNAT session {}, "
-                       "series {}".format(xnat_scan.session, xnat_scan.series))
+                       "series {}".format(xnat_scan.subject, xnat_scan.series))
         return None
     return base_dir
 

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -237,7 +237,7 @@ def process_experiment(project, ident):
             db_session = dashboard.get_session(ident, create=True)
         except dashboard.DashboardException as e:
             logger.error("Failed adding session {}. Reason: {}".format(
-                    experiment_label, e))
+                experiment_label, e))
         else:
             set_alt_ids(db_session, ident)
             set_date(db_session, xnat_experiment)

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -210,7 +210,7 @@ def collect_all_experiments(xnat_projects, config):
                 continue
             if (ident.session is None and not datman.scanid.is_phantom(ident)):
                 logger.error("Invalid experiment ID {} in project {}. Reason "
-                             "- Not a phantom, but missing series number"
+                             "- Not a phantom, but missing session number"
                              "".format(exper_id, project))
                 continue
             experiments.append((project, ident))

--- a/bin/dm_xnat_upload.py
+++ b/bin/dm_xnat_upload.py
@@ -268,7 +268,7 @@ def scan_data_exists(xnat_experiment, local_headers):
         raise ValueError("More than one experiment UID found - "
                          "{}".format(",".join(local_experiment_ids)))
 
-    if xnat_experiment.experiment_UID not in local_experiment_ids:
+    if xnat_experiment.uid not in local_experiment_ids:
         raise ValueError("Experiment UID doesnt match XNAT")
 
     if not set(local_scan_uids).issubset(set(xnat_experiment.scan_UIDs)):

--- a/bin/dm_xnat_upload.py
+++ b/bin/dm_xnat_upload.py
@@ -36,17 +36,11 @@ import datman.exceptions
 
 logger = logging.getLogger(os.path.basename(__file__))
 
-username = None
-password = None
-server = None
 XNAT = None
 CFG = None
 
 
 def main():
-    global username
-    global server
-    global password
     global XNAT
     global CFG
 
@@ -79,9 +73,6 @@ def main():
     ch.setFormatter(formatter)
 
     logger.addHandler(ch)
-
-    # setup the config object
-    logger.info('Loading config')
 
     CFG = datman.config.config(study=study)
 

--- a/bin/dm_xnat_upload.py
+++ b/bin/dm_xnat_upload.py
@@ -97,7 +97,7 @@ def main():
     else:
         archives = os.listdir(dicom_dir)
 
-    logger.debug("Processing files in:{}".format(dicom_dir))
+    logger.debug("Processing files in: {}".format(dicom_dir))
     logger.info("Processing {} files".format(len(archives)))
 
     for archivefile in archives:

--- a/bin/dm_xnat_upload.py
+++ b/bin/dm_xnat_upload.py
@@ -7,7 +7,7 @@ Usage:
     dm_xnat_upload.py [options] <study> <archive>
 
 Arguments:
-    <study>             Study/Project name
+    <study>               Study/Project name
     <archive>             Properly named zip file
 
 Options:
@@ -45,13 +45,13 @@ def main():
     global CFG
 
     arguments = docopt(__doc__)
-    verbose = arguments['--verbose']
-    debug = arguments['--debug']
-    quiet = arguments['--quiet']
-    study = arguments['<study>']
-    server = arguments['--server']
-    username = arguments['--username']
-    archive = arguments['<archive>']
+    verbose = arguments["--verbose"]
+    debug = arguments["--debug"]
+    quiet = arguments["--quiet"]
+    study = arguments["<study>"]
+    server = arguments["--server"]
+    username = arguments["--username"]
+    archive = arguments["<archive>"]
 
     # setup logging
     ch = logging.StreamHandler(sys.stdout)
@@ -67,8 +67,8 @@ def main():
         logger.setLevel(logging.DEBUG)
         ch.setLevel(logging.DEBUG)
 
-    formatter = logging.Formatter('%(asctime)s - %(name)s - {study} - '
-                                  '%(levelname)s - %(message)s'.format(
+    formatter = logging.Formatter("%(asctime)s - %(name)s - {study} - "
+                                  "%(levelname)s - %(message)s".format(
                                    study=study))
     ch.setFormatter(formatter)
 
@@ -80,7 +80,7 @@ def main():
     username, password = datman.xnat.get_auth(username)
     XNAT = datman.xnat.xnat(server, username, password)
 
-    dicom_dir = CFG.get_path('dicom', study)
+    dicom_dir = CFG.get_path("dicom", study)
     # deal with a single archive specified on the command line,
     # otherwise process all files in dicom_dir
     if archive:
@@ -90,15 +90,15 @@ def main():
             archives = [os.path.basename(os.path.normpath(archive))]
         elif is_datman_id(archive):
             # sessionid could have been provided, lets be nice and handle that
-            archives = [datman.utils.splitext(archive)[0] + '.zip']
+            archives = [datman.utils.splitext(archive)[0] + ".zip"]
         else:
-            logger.error('Cant find archive:{}'.format(archive))
+            logger.error("Cant find archive:{}".format(archive))
             return
     else:
         archives = os.listdir(dicom_dir)
 
-    logger.debug('Processing files in:{}'.format(dicom_dir))
-    logger.info('Processing {} files'.format(len(archives)))
+    logger.debug("Processing files in:{}".format(dicom_dir))
+    logger.info("Processing {} files".format(len(archives)))
 
     for archivefile in archives:
         process_archive(os.path.join(dicom_dir, archivefile))
@@ -113,39 +113,64 @@ def is_datman_id(archive):
 
 def process_archive(archivefile):
     """Upload data from a zip archive to the xnat server"""
+
     scanid = get_scanid(os.path.basename(archivefile))
     if not scanid:
         return
+
+    try:
+        convention = CFG.get_key("XNAT_CONVENTION", site=scanid.site).upper()
+    except datman.config.UndefinedSetting:
+        convention = "DATMAN"
+
+    if convention == "KCNI":
+        try:
+            settings = CFG.get_key("ID_MAP")
+        except datman.config.UndefinedSetting:
+            settings = None
+        try:
+            scanid = datman.scanid.get_kcni_id(scanid, settings)
+        except datman.scanid.ParseException:
+            logger.error("ID {} can't be converted to KCNI convention.".format(
+                scanid))
+            return
 
     xnat_subject = get_xnat_subject(scanid)
     if not xnat_subject:
         # failed to get xnat info
         return
 
+    exper_id = scanid.get_xnat_experiment_id()
     try:
-        data_exists, resource_exists = check_files_exist(archivefile,
-                                                         xnat_subject)
-    except Exception:
-        logger.error('Failed checking xnat for session: {}'.format(scanid))
-        return
+        xnat_experiment = xnat_subject.experiments[exper_id]
+    except KeyError:
+        data_exists = False
+        resource_exists = False
+    else:
+        try:
+            data_exists, resource_exists = check_files_exist(archivefile,
+                                                             xnat_experiment)
+        except Exception:
+            logger.error("Failed checking xnat for experiment {}".format(
+                exper_id))
+            return
 
     if not data_exists:
-        logger.info('Uploading dicoms from: {}'.format(archivefile))
+        logger.info("Uploading dicoms from {}".format(archivefile))
         try:
-            upload_dicom_data(archivefile, xnat_subject.project, str(scanid))
+            upload_dicom_data(archivefile, xnat_subject.project, scanid)
         except Exception as e:
-            logger.error('Failed uploading archive to xnat project: {}'
-                         ' for subject: {}. Check Prearchive.'
-                         .format(xnat_subject.project, str(scanid)))
-            logger.info('Upload failed with reason: {}'.format(str(e)))
+            logger.error("Failed uploading archive to xnat project {} "
+                         "for experiment {}. Check Prearchive. Reason - {}"
+                         .format(xnat_subject.project, xnat_experiment.name,
+                                 e))
 
     if not resource_exists:
-        logger.debug('Uploading resource from: {}'.format(archivefile))
+        logger.debug("Uploading resource from: {}".format(archivefile))
         try:
-            upload_non_dicom_data(archivefile, xnat_subject.project,
-                                  str(scanid))
+            upload_non_dicom_data(archivefile, xnat_subject.project, scanid)
         except Exception as e:
-            logger.debug('An exception occurred: {}'.format(e))
+            logger.debug("An exception occurred: {}".format(e))
             pass
 
 
@@ -164,34 +189,36 @@ def get_xnat_subject(ident):
     """
     # get the expected xnat project name from the config filename
     try:
-        xnat_project = CFG.get_key('XNAT_Archive',
+        xnat_project = CFG.get_key("XNAT_Archive",
                                    site=ident.site)
     except datman.config.UndefinedSetting:
-        logger.warning('Study {}, Site {}, xnat archive not defined in config'
+        logger.warning("Study {}, Site {}, xnat archive not defined in config"
                        .format(ident.study, ident.site))
         return None
     # check we can get the archive from xnat
     try:
-        found = XNAT.get_project(xnat_project)
+        found = XNAT.get_projects(xnat_project)
     except datman.exceptions.XnatException as e:
-        logger.error('Failed to get XNAT project {} for study {} and site '
-                     '{}. Reason - {}'.format(xnat_project, ident.study,
+        logger.error("Failed to get XNAT project {} for study {} and site "
+                     "{}. Reason - {}".format(xnat_project, ident.study,
                                               ident.site, e))
         return None
 
     if not found:
-        logger.error('No match found for XNAT project {} on server {}'.format(
+        logger.error("No match found for XNAT project {} on server {}".format(
             xnat_project, XNAT.server))
         return None
 
     # check we can get or create the session in xnat
     try:
-        xnat_subject = XNAT.get_subject(xnat_project, str(ident), create=True)
+        xnat_subject = XNAT.get_subject(xnat_project,
+                                        ident.get_xnat_subject_id(),
+                                        create=True)
     except datman.exceptions.XnatException as e:
-        logger.error('Study:{}, site:{}, archive:{} Failed getting session:{}'
-                     ' from xnat with reason:{}'
+        logger.error("Study {}, site {}, archive {} Failed getting session {}"
+                     " from xnat with reason {}"
                      .format(ident.study, ident.site,
-                             xnat_project, str(ident), e))
+                             xnat_project, ident.get_xnat_subject_id(), e))
         return None
 
     return xnat_subject
@@ -206,7 +233,7 @@ def get_scanid(archivefile):
 
     if not datman.scanid.is_scanid_with_session(scanid) and \
        not datman.scanid.is_phantom(scanid):
-        logger.error('Invalid scanid:{} from archive:{}'
+        logger.error("Invalid ID {} found for archive {}"
                      .format(scanid, archivefile))
         return False
 
@@ -214,8 +241,8 @@ def get_scanid(archivefile):
     return(ident)
 
 
-def resource_data_exists(xnat_session, archive):
-    xnat_resources = xnat_session.get_resources(XNAT)
+def resource_data_exists(xnat_experiment, archive):
+    xnat_resources = xnat_experiment.get_resources(XNAT)
     with zipfile.ZipFile(archive) as zf:
         local_resources = datman.utils.get_resources(zf)
         local_resources_mod = [item for item in local_resources
@@ -223,7 +250,7 @@ def resource_data_exists(xnat_session, archive):
     empty_files = list(set(local_resources) - set(local_resources_mod))
     if empty_files:
         logger.warn("Cannot upload empty resource files {}, omitting."
-                    "".format(', '.join(empty_files)))
+                    "".format(", ".join(empty_files)))
     # paths in xnat are url encoded. Need to fix local paths to match
     local_resources_mod = [urllib.request.pathname2url(p)
                            for p in local_resources_mod]
@@ -232,54 +259,54 @@ def resource_data_exists(xnat_session, archive):
     return True
 
 
-def scan_data_exists(xnat_session, local_headers):
+def scan_data_exists(xnat_experiment, local_headers):
     local_scan_uids = [scan.SeriesInstanceUID
                        for scan in local_headers.values()]
     local_experiment_ids = [v.StudyInstanceUID for v in local_headers.values()]
 
     if len(set(local_experiment_ids)) > 1:
-        raise ValueError('More than one experiment UID found - '
-                         '{}'.format(','.join(local_experiment_ids)))
+        raise ValueError("More than one experiment UID found - "
+                         "{}".format(",".join(local_experiment_ids)))
 
-    if xnat_session.experiment_UID not in local_experiment_ids:
-        raise ValueError('Experiment UID doesnt match XNAT')
+    if xnat_experiment.experiment_UID not in local_experiment_ids:
+        raise ValueError("Experiment UID doesnt match XNAT")
 
-    if not set(local_scan_uids).issubset(set(xnat_session.scan_UIDs)):
-        logger.info('Found UIDs for {} not yet added to xnat'.format(
-                xnat_session.name))
+    if not set(local_scan_uids).issubset(set(xnat_experiment.scan_UIDs)):
+        logger.info("Found UIDs for {} not yet added to xnat".format(
+                xnat_experiment.name))
         return False
 
     # XNAT data matches local archive data
     return True
 
 
-def check_files_exist(archive, xnat_session):
+def check_files_exist(archive, xnat_experiment):
     """Check to see if the dicom files in the local archive have
     been uploaded to xnat
     Returns True if all files exist, otherwise False
     If the session UIDs don't match raises a warning"""
-    logger.info('Checking {} contents on xnat'.format(xnat_session.name))
+    logger.info("Checking {} contents on xnat".format(xnat_experiment.name))
     try:
         local_headers = datman.utils.get_archive_headers(archive)
     except Exception:
-        logger.error('Failed getting zip file headers for: {}'.format(archive))
+        logger.error("Failed getting zip file headers for: {}".format(archive))
         return False, False
 
     if not local_headers:
-        resources_exist = resource_data_exists(xnat_session, archive)
+        resources_exist = resource_data_exists(xnat_experiment, archive)
         return True, resources_exist
 
-    if not xnat_session.scans:
+    if not xnat_experiment.scans:
         return False, False
 
     try:
-        scans_exist = scan_data_exists(xnat_session, local_headers)
+        scans_exist = scan_data_exists(xnat_experiment, local_headers)
     except ValueError as e:
         logger.debug("Please check {}: {}".format(archive, e))
         # Return true for both to prevent XNAT being modified
         return True, True
 
-    resources_exist = resource_data_exists(xnat_session, archive)
+    resources_exist = resource_data_exists(xnat_experiment, archive)
 
     return scans_exist, resources_exist
 
@@ -298,11 +325,11 @@ def upload_non_dicom_data(archive, xnat_project, scanid):
                 # if this is changed it may require changes to
                 # check_duplicate_resources()
                 XNAT.put_resource(xnat_project,
-                                  scanid,
-                                  scanid,
+                                  scanid.get_xnat_subject_id(),
+                                  scanid.get_xnat_experiment_id(),
                                   item,
                                   contents,
-                                  'MISC')
+                                  "MISC")
                 uploaded_files.append(item)
             except Exception as e:
                 logger.error("Failed uploading file {} with error:{}"
@@ -317,7 +344,8 @@ def upload_dicom_data(archive, xnat_project, scanid):
     # upload_non_dicom_data and added to resources - Dawn
 
     if not contains_niftis(archive):
-        XNAT.put_dicoms(xnat_project, scanid, scanid, archive)
+        XNAT.put_dicoms(xnat_project, scanid.get_xnat_subject_id(),
+                        scanid.get_xnat_experiment_id(), archive)
         return
 
     # Need to account for when only niftis are available
@@ -325,10 +353,11 @@ def upload_dicom_data(archive, xnat_project, scanid):
         new_archive = strip_niftis(archive, temp)
 
         if new_archive:
-            XNAT.put_dicoms(xnat_project, scanid, scanid, new_archive)
+            XNAT.put_dicoms(xnat_project, scanid.get_xnat_subject_id(),
+                            scanid.get_xnat_experiment_id(), new_archive)
         else:
-            logger.info('No dicoms exist within archive {}, skipping dicom '
-                        'upload!'.format(archive))
+            logger.info("No dicoms exist within archive {}, skipping dicom "
+                        "upload!".format(archive))
 
 
 def contains_niftis(archive):
@@ -343,7 +372,7 @@ def strip_niftis(archive, temp):
     Extract the everything except niftis to temp folder, rezip, and then
     return the path to this temporary zip for upload
     """
-    unzip_dest = datman.utils.define_folder(os.path.join(temp, 'extracted'))
+    unzip_dest = datman.utils.define_folder(os.path.join(temp, "extracted"))
     with zipfile.ZipFile(archive) as zf:
         archive_files = zf.namelist()
         niftis = find_niftis(archive_files)
@@ -358,7 +387,7 @@ def strip_niftis(archive, temp):
 
         # Check if any dicoms exist at all
         non_niftis_or_paths = [i for i in non_niftis
-                               if not os.path.basename(i) == '']
+                               if not os.path.basename(i) == ""]
 
         if not non_niftis_or_paths:
             return []
@@ -375,5 +404,5 @@ def find_niftis(files):
     return [x for x in files if x.endswith(".nii") or x.endswith(".nii.gz")]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/bin/dm_xnat_upload.py
+++ b/bin/dm_xnat_upload.py
@@ -273,7 +273,7 @@ def scan_data_exists(xnat_experiment, local_headers):
 
     if not set(local_scan_uids).issubset(set(xnat_experiment.scan_UIDs)):
         logger.info("Found UIDs for {} not yet added to xnat".format(
-                xnat_experiment.name))
+            xnat_experiment.name))
         return False
 
     # XNAT data matches local archive data

--- a/bin/dm_xnat_upload.py
+++ b/bin/dm_xnat_upload.py
@@ -129,7 +129,7 @@ def process_archive(archivefile):
         except datman.config.UndefinedSetting:
             settings = None
         try:
-            scanid = datman.scanid.get_kcni_id(scanid, settings)
+            scanid = datman.scanid.get_kcni_identifier(scanid, settings)
         except datman.scanid.ParseException:
             logger.error("ID {} can't be converted to KCNI convention.".format(
                 scanid))

--- a/bin/xnat_fetch_sessions.py
+++ b/bin/xnat_fetch_sessions.py
@@ -132,7 +132,7 @@ def download_subjects(xnat, xnat_project, destination):
             if zip_name in current_zips and not update_needed(
                     zip_path, experiment, xnat):
                 logger.debug("All data downloaded for {}. Passing.".format(
-                        experiment.name))
+                    experiment.name))
                 continue
 
             if DRYRUN:

--- a/datman/exceptions.py
+++ b/datman/exceptions.py
@@ -1,6 +1,12 @@
 """Defines the exceptions used by datman sub-modules"""
 
 
+class ParseException(Exception):
+    """For participant ID parsing issues.
+    """
+    pass
+
+
 class XnatException(Exception):
     """Default exception for xnat errors"""
     study = None

--- a/datman/fs_log_scraper.py
+++ b/datman/fs_log_scraper.py
@@ -158,7 +158,7 @@ class FSLog(object):
 
         _, date_str = date_entry[0].strip('\n').split(None, 1)
         date = self.get_date(date_str)
-        now = datetime.datetime.now()
+        now = datetime.datetime.now(date.tzinfo)
         diff = now - date
         if diff < datetime.timedelta(hours=24):
             status = self._RUNNING

--- a/datman/scanid.py
+++ b/datman/scanid.py
@@ -253,18 +253,18 @@ class BIDSFile(object):
 
 
 FILENAME_RE = DatmanIdentifier.scan_re + '_' + \
-              r'(?P<tag>[^_]+)_' + \
-              r'(?P<series>\d+)_' + \
-              r'(?P<description>.*?)' + \
-              r'(?P<ext>.nii.gz|.nii|.json|.bvec|.bval|.tar.gz|.tar|.dcm|' + \
-              r'.IMA|.mnc|.nrrd|$)'
+    r'(?P<tag>[^_]+)_' + \
+    r'(?P<series>\d+)_' + \
+    r'(?P<description>.*?)' + \
+    r'(?P<ext>.nii.gz|.nii|.json|.bvec|.bval|.tar.gz|.tar|.dcm|' + \
+    r'.IMA|.mnc|.nrrd|$)'
 
 FILENAME_PHA_RE = DatmanIdentifier.pha_re + '_' + \
-              r'(?P<tag>[^_]+)_' + \
-              r'(?P<series>\d+)_' + \
-              r'(?P<description>.*?)' + \
-              r'(?P<ext>.nii.gz|.nii|.json|.bvec|.bval|.tar.gz|.tar|.dcm|' + \
-              r'.IMA|.mnc|.nrrd|$)'
+    r'(?P<tag>[^_]+)_' + \
+    r'(?P<series>\d+)_' + \
+    r'(?P<description>.*?)' + \
+    r'(?P<ext>.nii.gz|.nii|.json|.bvec|.bval|.tar.gz|.tar|.dcm|' + \
+    r'.IMA|.mnc|.nrrd|$)'
 
 BIDS_SCAN_RE = r'sub-(?P<subject>[A-Z0-9]+)_' + \
                r'ses-(?P<session>[A-Za-z0-9]+)_' + \

--- a/datman/scanid.py
+++ b/datman/scanid.py
@@ -7,13 +7,11 @@
     get_full_subjectid and other similar methods are called. The original ID
     in its native convention can always be retrieved from 'orig_id'.
 """
+from abc import ABC
 import os.path
 import re
-from abc import ABC
 
-
-class ParseException(Exception):
-    pass
+from datman.exceptions import ParseException
 
 
 class Identifier(ABC):

--- a/datman/scanid.py
+++ b/datman/scanid.py
@@ -105,7 +105,7 @@ class DatmanIdentifier(Identifier):
     scan_pattern = re.compile('^' + scan_re + '$')
     pha_pattern = re.compile('^' + pha_re + '$')
 
-    def __init__(self, identifier):
+    def __init__(self, identifier, settings=None):
         match = self.match(identifier)
 
         if not match:
@@ -146,7 +146,7 @@ class KCNIIdentifier(Identifier):
 
     pha_re = '(?P<study>[A-Z]{3}[0-9]{2})_' \
              '(?P<site>[A-Z]{3})_' \
-             '(?P<pha_type>[A-Z]{3}PHA)_' \
+             '(?P<pha_type>[A-Z]{3})PHA_' \
              '(?P<subject>[0-9]{4})_MR' \
              '(?P<timepoint>)(?P<session>)'  # empty
 
@@ -157,17 +157,22 @@ class KCNIIdentifier(Identifier):
         match = self.match(identifier)
         if not match:
             raise ParseException("Invalid KCNI ID {}".format(identifier))
+
         # What about if a field has to be translated between conventions?
         self.study = match.group("study")
         self.site = match.group("site")
+
         self.subject = match.group("subject")
-        self.timepoint = match.group("timepoint")
-        self.session = match.group("session")
         try:
-            self.pha = match.group("pha_type")
+            self.pha_type = match.group("pha_type")
         except IndexError:
             # Not a phantom
-            pass
+            self.pha_type = None
+        else:
+            self.subject = "PHA_{}{}".format(self.pha_type, self.subject)
+
+        self.timepoint = match.group("timepoint")
+        self.session = match.group("session")
 
     def __repr__(self):
         return '<datman.scanid.KCNIIdentifier {}>'.format(self.__str__())

--- a/datman/scanid.py
+++ b/datman/scanid.py
@@ -7,7 +7,7 @@
     get_full_subjectid and other similar methods are called. The original ID
     in its native convention can always be retrieved from 'orig_id'.
 """
-from abc import ABC
+from abc import ABC, abstractmethod
 import os.path
 import re
 
@@ -42,6 +42,14 @@ class Identifier(ABC):
         if self.session:
             ident += "_" + self.session
         return ident
+
+    @abstractmethod
+    def get_xnat_subject_id(self):
+        pass
+
+    @abstractmethod
+    def get_xnat_experiment_id(self):
+        pass
 
     def __str__(self):
         if self.session:
@@ -102,6 +110,12 @@ class DatmanIdentifier(Identifier):
     def session(self, value):
         self._session = value
 
+    def get_xnat_subject_id(self):
+        return self.get_full_subjectid_with_timepoint_session()
+
+    def get_xnat_experiment_id(self):
+        return self.xnat_subject_id()
+
     def __repr__(self):
         return '<datman.scanid.DatmanIdentifier {}>'.format(self.__str__())
 
@@ -152,6 +166,19 @@ class KCNIIdentifier(Identifier):
 
         self.timepoint = match.group('timepoint')
         self.session = match.group('session')
+
+    def get_xnat_subject_id(self):
+        study = self._match_groups.group("study")
+        site = self._match_groups.group("site")
+        subject = self._match_groups.group("subject")
+        if self.pha_type:
+            subject = self.pha_type + "PHA"
+        else:
+            subject = self._match_groups.group("subject")
+        return "_".join([study, site, subject])
+
+    def get_xnat_experiment_id(self):
+        return self.orig_id
 
     def __repr__(self):
         return '<datman.scanid.KCNIIdentifier {}>'.format(self.__str__())

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -344,7 +344,7 @@ class xnat(object):
             raise XnatException("Could not access metadata for experiment "
                                 "{}".format(exper_id))
 
-        return XNATExperiment(subject_id, exper_json)
+        return XNATExperiment(project, subject_id, exper_json)
 
     def make_experiment(self, project, subject, experiment):
         """Make a new (empty) experiment on the XNAT server.
@@ -971,7 +971,7 @@ class XNATSubject(XNATObject):
 
         found = {}
         for item in experiments[0]["items"]:
-            exper = XNATExperiment(self.name, item)
+            exper = XNATExperiment(self.project, self.name, item)
             found[exper.name] = exper
 
         return found
@@ -985,8 +985,9 @@ class XNATSubject(XNATObject):
 
 class XNATExperiment(XNATObject):
 
-    def __init__(self, subject_name, experiment_json):
+    def __init__(self, project, subject_name, experiment_json):
         self.raw_json = experiment_json
+        self.project = project
         self.subject = subject_name
         self.uid = self._get_field("UID")
         self.id = self._get_field("ID")
@@ -1109,8 +1110,8 @@ class XNATExperiment(XNATObject):
         for r_id in resource_ids:
             resource_list = xnat_connection.get_resource_list(
                                     self.project,
+                                    self.subject,
                                     self.name,
-                                    self.experiment_label,
                                     r_id)
             resources.extend([item["URI"] for item in resource_list])
         return resources
@@ -1145,7 +1146,7 @@ class XNATExperiment(XNATObject):
                             ",".join(resources_list)))
 
         if not zip_name:
-            zip_name = self.experiment.upper() + ".zip"
+            zip_name = self.name.upper() + ".zip"
 
         output_path = os.path.join(dest_folder, zip_name)
         if os.path.exists(output_path):

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -638,7 +638,8 @@ class xnat(object):
             except OSError as e:
                 logger.warning("Failed to delete tempfile: {} with excuse: {}"
                                .format(filename, str(e)))
-            err = XnatException("Failed getting dicom with url: {}".format(url))
+            err = XnatException("Failed getting dicom with url: "
+                                "{}".format(url))
             err.study = project
             err.session = session
             raise err
@@ -957,6 +958,12 @@ class xnat(object):
             logger.warn("http client error deleting resource: {}"
                         .format(response.status_code))
             response.raise_for_status()
+
+    def __str__(self):
+        return "<datman.xnat.xnat {}>".format(self.server)
+
+    def __repr__(self):
+        return self.__str__()
 
 
 class XNATObject(ABC):

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -8,6 +8,7 @@ import urllib.parse
 import getpass
 import re
 from xml.etree import ElementTree
+from abc import ABC
 
 import requests
 
@@ -214,7 +215,7 @@ class xnat(object):
                             study)
             raise XnatException(msg)
 
-        return Session(session_json)
+        return XNATSession(session_json)
 
     def make_session(self, study, session):
         url = "{server}/REST/projects/{project}/subjects/{subject}"
@@ -835,20 +836,50 @@ class xnat(object):
             response.raise_for_status()
 
 
-class Session(object):
+class XNATObject(ABC):
+    def _get_field(self, key):
+        if not self.raw_json['data_fields']:
+            return ''
+        return self.raw_json['data_fields'].get(key, '')
 
-    raw_json = None
+
+class XNATSession(XNATObject):
 
     def __init__(self, session_json):
-        # Session attributes
         self.raw_json = session_json
-        self.name = session_json['data_fields']['label']
-        self.project = session_json['data_fields']['project']
+        self.name = self._get_field('label')
+        self.project = self._get_field('project')
+        self.experiments = self._get_experiments()
 
-        # Experiment attributes
-        self.experiment = self._get_experiment()
-        self.experiment_label = self._get_experiment_label()
-        self.experiment_UID = self._get_experiment_UID()
+    def _get_experiments(self):
+        experiments = [exp for exp in self.raw_json['children']
+                       if exp['field'] == 'experiments/experiment']
+
+        if not experiments:
+            logger.debug("No experiments found for {}".format(self.name))
+            return {}
+
+        found = {}
+        for item in experiments[0]['items']:
+            exper = XNATExperiment(self.name, item)
+            found[exper.name] = exper
+
+        return found
+
+    def __str__(self):
+        return "<XNATSession {}>".format(self.name)
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class XNATExperiment(XNATObject):
+
+    def __init__(self, session_name, experiment_json):
+        self.raw_json = experiment_json
+        self.session = session_name
+        self.uid = self._get_field('UID')
+        self.name = self._get_field('label')
 
         # Scan attributes
         self.scans = self._get_scans()
@@ -856,70 +887,27 @@ class Session(object):
         self.scan_resource_IDs = self._get_scan_rIDs()
 
         # Resource attributes
-        self.resource_files = self._get_experiment_contents(
-                                            'resources/resource')
+        self.resource_files = self._get_contents('resources/resource')
         self.resource_IDs = self._get_resource_IDs()
 
-        # Misc - basically just OPT CU1 needs this
-        self.misc_resource_IDs = self._get_other_resource_IDs()
+        # # Misc - basically just OPT CU1 needs this
+        # self.misc_resource_IDs = self._get_other_resource_IDs()
 
-    def _get_experiment(self):
-        experiments = [exp for exp in self.raw_json['children']
-                       if exp['field'] == 'experiments/experiment']
-
-        if not experiments:
-            logger.debug("No experiments found for {}".format(self.name))
-            return {}
-        elif len(experiments) > 1:
-            logger.error("More than one session uploaded to ID {}. Processing "
-                         "only the first.".format(self.name))
-
-        return experiments[0]['items'][0]
-
-    def _get_experiment_label(self):
-        if not self.experiment:
-            return ''
-        try:
-            label = self.experiment['data_fields']['label']
-        except KeyError:
-            logger.error("Could not retrieve experiment label for {}".format(
-                    self.name))
-            label = ''
-        return label
-
-    def _get_experiment_UID(self):
-        if not self.experiment:
-            return ''
-        try:
-            uid = self.experiment['data_fields']['UID']
-        except KeyError:
-            uid = ''
-        return uid
-
-    def _get_experiment_contents(self, field):
-        """
-        Retrieves part of the contents of an experiment based on 'field'.
-        e.g. 'scans/scan' or 'resources/resource'
-        """
-        try:
-            children = self.experiment['children']
-        except KeyError:
-            # Nothing uploaded for this experiment
-            children = []
+    def _get_contents(self, data_type):
+        children = self.raw_json.get('children', [])
 
         contents = [child['items'] for child in children
-                    if child['field'] == field]
+                    if child['field'] == data_type]
         return contents
 
     def _get_scans(self):
-        scans = self._get_experiment_contents('scans/scan')
+        scans = self._get_contents('scans/scan')
         if not scans:
-            logger.debug("No scans found for session {}".format(self.name))
+            logger.debug("No scans found for experiment {}".format(self.name))
             return scans
         xnat_scans = []
         for scan_json in scans[0]:
-            xnat_scans.append(XNATScan(self.name, self.experiment_label,
-                                       self.project, scan_json))
+            xnat_scans.append(XNATSeries(self.name, scan_json))
         return xnat_scans
 
     def _get_scan_UIDs(self):
@@ -949,153 +937,147 @@ class Session(object):
 
         resource_ids = {}
         for resource in self.resource_files[0]:
-            try:
-                label = resource['data_fields']['label']
-            except KeyError:
-                label = 'No Label'
+            label = resource['data_fields'].get('label', 'No Label')
             resource_ids[label] = str(resource['data_fields'][
                                                 'xnat_abstractresource_id'])
         return resource_ids
 
-    def _get_other_resource_IDs(self):
-        """
-        OPT's CU site uploads niftis to their server. These niftis are neither
-        classified as resources nor as scans so our code misses them entirely.
-        This functions grabs the abstractresource_id for these and
-        any other unique files aside from snapshots so they can be downloaded
-        """
-        r_ids = []
-        for scan in self.scans:
-            for child in scan.raw_json['children']:
-                for file_upload in child['items']:
-                    data_fields = file_upload['data_fields']
-                    try:
-                        label = data_fields['label']
-                    except KeyError:
-                        # Some entries dont have labels. Only hold some header
-                        # values. These are safe to ignore
-                        continue
+    # def _get_other_resource_IDs(self):
+    #     """
+    #     OPT's CU site uploads niftis to their server. These niftis are neither
+    #     classified as resources nor as scans so our code misses them entirely.
+    #     This functions grabs the abstractresource_id for these and
+    #     any other unique files aside from snapshots so they can be downloaded
+    #     """
+    #     r_ids = []
+    #     for scan in self.scans:
+    #         for child in scan.raw_json['children']:
+    #             for file_upload in child['items']:
+    #                 data_fields = file_upload['data_fields']
+    #                 try:
+    #                     label = data_fields['label']
+    #                 except KeyError:
+    #                     # Some entries dont have labels. Only hold some header
+    #                     # values. These are safe to ignore
+    #                     continue
 
-                    try:
-                        data_format = data_fields['format']
-                    except KeyError:
-                        # Some entries have labels but no format... or neither
-                        if not label:
-                            # If neither, ignore. Should just be an entry
-                            # containing scan parameters, etc.
-                            continue
-                        data_format = label
+    #                 try:
+    #                     data_format = data_fields['format']
+    #                 except KeyError:
+    #                     # Some entries have labels but no format... or neither
+    #                     if not label:
+    #                         # If neither, ignore. Should just be an entry
+    #                         # containing scan parameters, etc.
+    #                         continue
+    #                     data_format = label
 
-                    try:
-                        r_id = str(data_fields['xnat_abstractresource_id'])
-                    except KeyError:
-                        # Some entries have labels and/or a format but no
-                        # actual files and so no resource id. These can also be
-                        # safely ignored.
-                        continue
+    #                 try:
+    #                     r_id = str(data_fields['xnat_abstractresource_id'])
+    #                 except KeyError:
+    #                     # Some entries have labels and/or a format but no
+    #                     # actual files and so no resource id. These can also be
+    #                     # safely ignored.
+    #                     continue
 
-                    # ignore DICOM, it's grabbed elsewhere. Ignore snapshots
-                    # entirely. Some things may not be labelled DICOM but may
-                    # be format 'DICOM' so that needs to be checked for too.
-                    if label != 'DICOM' and (data_format != 'DICOM' and
-                                             label != 'SNAPSHOTS'):
-                        r_ids.append(r_id)
-        return r_ids
+    #                 # ignore DICOM, it's grabbed elsewhere. Ignore snapshots
+    #                 # entirely. Some things may not be labelled DICOM but may
+    #                 # be format 'DICOM' so that needs to be checked for too.
+    #                 if label != 'DICOM' and (data_format != 'DICOM' and
+    #                                          label != 'SNAPSHOTS'):
+    #                     r_ids.append(r_id)
+    #     return r_ids
 
-    def get_resources(self, xnat_connection):
-        """
-        Returns a list of all resource URIs from this session.
-        """
-        resources = []
-        resource_ids = list(self.resource_IDs.values())
-        resource_ids.extend(self.misc_resource_IDs)
-        for r_id in resource_ids:
-            resource_list = xnat_connection.get_resource_list(
-                                    self.project,
-                                    self.name,
-                                    self.experiment_label,
-                                    r_id)
-            resources.extend([item['URI'] for item in resource_list])
-        return resources
+    # def get_resources(self, xnat_connection):
+    #     """
+    #     Returns a list of all resource URIs from this session.
+    #     """
+    #     resources = []
+    #     resource_ids = list(self.resource_IDs.values())
+    #     resource_ids.extend(self.misc_resource_IDs)
+    #     for r_id in resource_ids:
+    #         resource_list = xnat_connection.get_resource_list(
+    #                                 self.project,
+    #                                 self.name,
+    #                                 self.experiment_label,
+    #                                 r_id)
+    #         resources.extend([item['URI'] for item in resource_list])
+    #     return resources
 
-    def download(self, xnat, dest_folder, zip_name=None):
-        """
-        Download a zip file containing all data for this session. Returns the
-        path to the new file if download is successful, raises an exception if
-        not
+    # def download(self, xnat, dest_folder, zip_name=None):
+    #     """
+    #     Download a zip file containing all data for this session. Returns the
+    #     path to the new file if download is successful, raises an exception if
+    #     not
 
-        xnat                An instance of datman.xnat.xnat()
-        dest_folder         The absolute path to the folder where the zip
-                            should be deposited
-        zip_name            An optional name for the output zip file. If not
-                            set the zip name will be session.name
-        """
-        if not self.experiment:
-            raise ValueError("No data found for {}".format(self.name))
+    #     xnat                An instance of datman.xnat.xnat()
+    #     dest_folder         The absolute path to the folder where the zip
+    #                         should be deposited
+    #     zip_name            An optional name for the output zip file. If not
+    #                         set the zip name will be session.name
+    #     """
+    #     if not self.experiment:
+    #         raise ValueError("No data found for {}".format(self.name))
 
-        try:
-            experiment_ID = self.experiment['data_fields']['ID']
-        except KeyError:
-            raise KeyError("Can't retrieve experiment ID for experiment {}. "
-                           "Please check contents.".format(
-                                                    self.experiment_label))
+    #     try:
+    #         experiment_ID = self.experiment['data_fields']['ID']
+    #     except KeyError:
+    #         raise KeyError("Can't retrieve experiment ID for experiment {}. "
+    #                        "Please check contents.".format(
+    #                                                 self.experiment_label))
 
-        # Grab dicoms
-        resources_list = self.scan_resource_IDs
-        # Grab what we define as resources (i.e. tech notes, non-dicoms)
-        resources_list.extend(list(self.resource_IDs.values()))
-        # Grab anything else other than snapshots (i.e. 'MUX' for OPT CU1)
-        resources_list.extend(self.misc_resource_IDs)
+    #     # Grab dicoms
+    #     resources_list = self.scan_resource_IDs
+    #     # Grab what we define as resources (i.e. tech notes, non-dicoms)
+    #     resources_list.extend(list(self.resource_IDs.values()))
+    #     # Grab anything else other than snapshots (i.e. 'MUX' for OPT CU1)
+    #     resources_list.extend(self.misc_resource_IDs)
 
-        if not resources_list:
-            raise ValueError("No scans or resources found for {}"
-                             "".format(self.name))
+    #     if not resources_list:
+    #         raise ValueError("No scans or resources found for {}"
+    #                          "".format(self.name))
 
-        url = ("{}/REST/experiments/{}/resources/{}/files"
-               "?structure=improved&all=true&format=zip".format(
-                            xnat.server,
-                            experiment_ID,
-                            ",".join(resources_list)))
+    #     url = ("{}/REST/experiments/{}/resources/{}/files"
+    #            "?structure=improved&all=true&format=zip".format(
+    #                         xnat.server,
+    #                         experiment_ID,
+    #                         ",".join(resources_list)))
 
-        if not zip_name:
-            zip_name = self.name.upper() + ".zip"
+    #     if not zip_name:
+    #         zip_name = self.name.upper() + ".zip"
 
-        output_path = os.path.join(dest_folder, zip_name)
-        if os.path.exists(output_path):
-            logger.error("Cannot download {}, file already exists.".format(
-                    output_path))
-            return output_path
+    #     output_path = os.path.join(dest_folder, zip_name)
+    #     if os.path.exists(output_path):
+    #         logger.error("Cannot download {}, file already exists.".format(
+    #                 output_path))
+    #         return output_path
 
-        xnat._get_xnat_stream(url, output_path)
+    #     xnat._get_xnat_stream(url, output_path)
 
-        return output_path
+    #     return output_path
 
     def __str__(self):
-        return "<XNATSession {}>".format(self.name)
+        return "<XNATExperiment {}>".format(self.name)
 
     def __repr__(self):
         return self.__str__()
 
 
-class XNATScan(object):
+class XNATSeries(XNATObject):
 
-    def __init__(self, session_name, experiment_name, project_name, scan_json):
-        self.project = project_name
-        self.session = session_name
-        self.experiment = experiment_name
-        self.uid = str(scan_json['data_fields']['UID'])
+    def __init__(self, experiment_name, scan_json):
         self.raw_json = scan_json
+        self.experiment = experiment_name
+        self.uid = self._get_field('UID')
+        self.series = self._get_field('ID')
+        self.image_type = self._get_field('parameters/imageType')
         self.multiecho = self.is_multiecho()
-        self.series = scan_json['data_fields']['ID']
         self.description = self._set_description()
-        self.image_type = scan_json['data_fields'].get('parameters/imageType')
 
     def _set_description(self):
-        if 'series_description' in self.raw_json['data_fields'].keys():
-            return self.raw_json['data_fields']['series_description']
-        elif 'type' in self.raw_json['data_fields'].keys():
-            return self.raw_json['data_fields']['type']
-        return None
+        series_descr = self._get_field('series_description')
+        if series_descr:
+            return series_descr
+        return self._get_field('type')
 
     def is_multiecho(self):
         try:
@@ -1162,7 +1144,8 @@ class XNATScan(object):
         names = []
         self.echo_dict = {}
         for tag in tag_settings:
-            name = "_".join([self.session, tag, padded_series, mangled_descr])
+            name = "_".join([self.experiment, tag, padded_series,
+                             mangled_descr])
             if self.multiecho:
                 echo_num = tag_settings[tag]['EchoNumber']
                 if echo_num not in self.echo_dict:
@@ -1178,7 +1161,7 @@ class XNATScan(object):
         return re.sub(r"[^a-zA-Z0-9.+]+", "-", self.description)
 
     def __str__(self):
-        return "<XNATScan {} - {}>".format(self.session, self.series)
+        return "<XNATSeries {} - {}>".format(self.experiment, self.series)
 
     def __repr__(self):
         return self.__str__()

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -447,7 +447,7 @@ class xnat(object):
         """
         logger.debug("Querying XNAT server {} for scan {} in experiment {} "
                      "belonging to subject {} in project {}".format(
-                        self.server, scan_id, exper_id, subject_id, project))
+                         self.server, scan_id, exper_id, subject_id, project))
 
         url = "{}/data/archive/projects/{}/subject_ids/{}/exper_ids/{}" \
               "/scans/{}/?format=json".format(
@@ -1073,7 +1073,7 @@ class XNATExperiment(XNATObject):
         for resource in self.resource_files[0]:
             label = resource["data_fields"].get("label", "No Label")
             resource_ids[label] = str(resource["data_fields"][
-                                                "xnat_abstractresource_id"])
+                "xnat_abstractresource_id"])
         return resource_ids
 
     def _get_other_resource_IDs(self):

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -1250,7 +1250,7 @@ class XNATScan(XNATObject):
         self.tags = list(matches.keys())
         return matches
 
-    def set_datman_name(self, tag_map):
+    def set_datman_name(self, base_name, tag_map):
         mangled_descr = self._mangle_descr()
         padded_series = self.series.zfill(2)
         tag_settings = self.set_tag(tag_map)
@@ -1260,7 +1260,7 @@ class XNATScan(XNATObject):
         names = []
         self.echo_dict = {}
         for tag in tag_settings:
-            name = "_".join([self.experiment, tag, padded_series,
+            name = "_".join([base_name, tag, padded_series,
                              mangled_descr])
             if self.multiecho:
                 echo_num = tag_settings[tag]["EchoNumber"]

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -447,7 +447,7 @@ class xnat(object):
         """
         logger.debug("Querying XNAT server {} for scan {} in experiment {} "
                      "belonging to subject {} in project {}".format(
-                        self.server, scan_id, exper_id, subject_id))
+                        self.server, scan_id, exper_id, subject_id, project))
 
         url = "{}/data/archive/projects/{}/subject_ids/{}/exper_ids/{}" \
               "/scans/{}/?format=json".format(
@@ -470,7 +470,7 @@ class xnat(object):
             raise XnatException("Could not access metadata for scan "
                                 "{}".format(scan_id))
 
-        return XNATScan(exper_id, scan_json)
+        return XNATScan(project, subject_id, exper_id, scan_json)
 
     def get_resource_ids(self, study, session, experiment, folderName=None,
                          create=True):
@@ -1033,7 +1033,8 @@ class XNATExperiment(XNATObject):
             return scans
         xnat_scans = []
         for scan_json in scans[0]:
-            xnat_scans.append(XNATScan(self.name, scan_json))
+            xnat_scans.append(XNATScan(self.project, self.subject, self.name,
+                                       scan_json))
         return xnat_scans
 
     def _get_scan_UIDs(self):
@@ -1180,8 +1181,10 @@ class XNATExperiment(XNATObject):
 
 class XNATScan(XNATObject):
 
-    def __init__(self, experiment_name, scan_json):
+    def __init__(self, project, subject_name, experiment_name, scan_json):
         self.raw_json = scan_json
+        self.project = project
+        self.subject = subject_name
         self.experiment = experiment_name
         self.uid = self._get_field("UID")
         self.series = self._get_field("ID")

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -1,14 +1,14 @@
 """Module to interact with the xnat server"""
 
+from abc import ABC
+import getpass
 import logging
+import os
+import re
 import time
 import tempfile
-import os
 import urllib.parse
-import getpass
-import re
 from xml.etree import ElementTree
-from abc import ABC
 
 import requests
 
@@ -208,14 +208,14 @@ class xnat(object):
                 result = self.get_session(study, session)
                 return result
         try:
-            session_json = result['items'][0]
+            subject_json = result['items'][0]
         except TypeError:
             msg = "Session {} doesn't exist on xnat for study {}".format(
                             session,
                             study)
             raise XnatException(msg)
 
-        return XNATSession(session_json)
+        return XNATSubject(subject_json)
 
     def make_session(self, study, session):
         url = "{server}/REST/projects/{project}/subjects/{subject}"
@@ -843,10 +843,10 @@ class XNATObject(ABC):
         return self.raw_json['data_fields'].get(key, '')
 
 
-class XNATSession(XNATObject):
+class XNATSubject(XNATObject):
 
-    def __init__(self, session_json):
-        self.raw_json = session_json
+    def __init__(self, subject_json):
+        self.raw_json = subject_json
         self.name = self._get_field('label')
         self.project = self._get_field('project')
         self.experiments = self._get_experiments()
@@ -867,7 +867,7 @@ class XNATSession(XNATObject):
         return found
 
     def __str__(self):
-        return "<XNATSession {}>".format(self.name)
+        return "<XNATSubject {}>".format(self.name)
 
     def __repr__(self):
         return self.__str__()
@@ -881,6 +881,7 @@ class XNATExperiment(XNATObject):
         self.uid = self._get_field('UID')
         self.id = self._get_field('ID')
         self.name = self._get_field('label')
+        self.date = self._get_field('date')
 
         # Scan attributes
         self.scans = self._get_scans()

--- a/tests/test_datman_scanid.py
+++ b/tests/test_datman_scanid.py
@@ -39,6 +39,16 @@ def test_parse_good_datman_scanid():
     assert ident.session == "02"
 
 
+def test_parse_good_datman_PHA_scanid():
+    ident = scanid.parse("DTI_CMH_PHA_ADN0001")
+    assert ident.study == "DTI"
+    assert ident.site == "CMH"
+    assert ident.subject == "PHA_ADN0001"
+    assert ident.timepoint == ""
+    assert ident.session == ""
+    assert str(ident) == "DTI_CMH_PHA_ADN0001"
+
+
 def test_parse_good_kcni_scanid():
     ident = scanid.parse("ABC01_CMH_12345678_01_SE02_MR")
     assert ident.study == 'ABC01'
@@ -46,6 +56,13 @@ def test_parse_good_kcni_scanid():
     assert ident.subject == '12345678'
     assert ident.timepoint == '01'
     assert ident.session == '02'
+
+
+def test_parse_good_kcni_PHA_scanid():
+    ident = scanid.parse("ABC01_CMH_LEGPHA_0001_MR")
+    assert ident.study == 'ABC01'
+    assert ident.site == 'CMH'
+    assert ident.subject == 'PHA_LEG0001'
 
 
 # def test_parse_and_modify_kcni_scanid_when_given_settings():
@@ -103,23 +120,6 @@ def test_is_kcni_scanid_good():
 def test_get_full_subjectid():
     ident = scanid.parse("DTI_CMH_H001_01_02")
     assert ident.get_full_subjectid() == "DTI_CMH_H001"
-
-
-def test_parse_datman_PHA_scanid():
-    ident = scanid.parse("DTI_CMH_PHA_ADN0001")
-    assert ident.study == "DTI"
-    assert ident.site == "CMH"
-    assert ident.subject == "PHA_ADN0001"
-    assert ident.timepoint == ""
-    assert ident.session == ""
-    assert str(ident) == "DTI_CMH_PHA_ADN0001"
-
-
-def test_parse_kcni_PHA_scanid():
-    ident = scanid.parse("ABC01_CMH_LEGPHA_0001_MR")
-    assert ident.study == 'ABC01'
-    assert ident.site == 'CMH'
-    assert ident.subject == 'LEG0001'
 
 
 def test_subject_id_with_timepoint():

--- a/tests/test_datman_scanid.py
+++ b/tests/test_datman_scanid.py
@@ -93,13 +93,9 @@ def test_parse_exception_when_kcni_subject_id_modality_missing():
         scanid.parse("DTI01_CMH_H001_01_SE02")
 
 
-def test_kcni_pha_id_parsed_as_datman_when_modality_missing():
-    # This isn't the behavior we want but unless the user specifies convention
-    # we can't catch that these kcni pha ids are malformed. This test is
-    # just to document that this happens. It's a good thing if it starts to
-    # fail :)
-    ident = scanid.parse("DTI01_CMH_ABCPHA_0001")
-    assert not isinstance(ident, scanid.KCNIIdentifier)
+def test_parse_exception_when_kcni_pha_id_modality_missing():
+    with pytest.raises(scanid.ParseException):
+        scanid.parse("DTI01_CMH_ABCPHA_0001")
 
 
 def test_parse_exception_when_kcni_session_malformed():

--- a/tests/test_datman_scanid.py
+++ b/tests/test_datman_scanid.py
@@ -1,18 +1,6 @@
 import datman.scanid as scanid
 import pytest
 
-# Settings to use for parse() tests
-SETTINGS = {
-    'ID_TYPE': 'KCNI',
-    'STUDY': {
-        'DTI01': 'DTI'
-    },
-    'SITE': {
-        'CMH': 'UT1',
-        'UTO': 'UT2'
-    }
-}
-
 
 def test_parse_empty():
     with pytest.raises(scanid.ParseException):
@@ -101,6 +89,43 @@ def test_parse_exception_when_kcni_pha_id_modality_missing():
 def test_parse_exception_when_kcni_session_malformed():
     with pytest.raises(scanid.ParseException):
         scanid.parse("DTI01_CMH_H001_01_02_MR")
+
+
+def test_user_settings_id_type_respected():
+    # Datman IDs should be rejected if user says to parse only KCNI IDs
+    with pytest.raises(scanid.ParseException):
+        scanid.parse("DTI01_CMH_H001_01_02", settings={'ID_TYPE': 'KCNI'})
+
+    # KCNI IDs should be rejected if the user says to parse only Datman IDs
+    with pytest.raises(scanid.ParseException):
+        scanid.parse("DTI01_CMH_H001_01_SE02_MR",
+                     settings={'ID_TYPE': 'DATMAN'})
+
+
+def test_kcni_study_field_is_modified_when_settings_given():
+    settings = {
+        'STUDY': {
+            'DTI01': 'DTI'
+        }
+    }
+    kcni_id = "DTI01_CMH_H001_01_SE02_MR"
+    ident = scanid.parse(kcni_id, settings=settings)
+
+    assert ident.study == 'DTI'
+    assert str(ident) == "DTI_CMH_H001_01_02"
+
+
+def test_kcni_site_field_is_modified_when_settings_given():
+    settings = {
+        'SITE': {
+            'UTO': 'UT2'
+        }
+    }
+    kcni_id = 'ABC01_UTO_12345678_01_SE02_MR'
+    ident = scanid.parse(kcni_id, settings=settings)
+
+    assert ident.site == 'UT2'
+    assert str(ident) == 'ABC01_UT2_12345678_01_02'
 
 
 def test_is_scanid_garbage():

--- a/tests/test_datman_scanid.py
+++ b/tests/test_datman_scanid.py
@@ -238,6 +238,38 @@ def test_id_field_changes_correct_for_repeat_conversions():
     assert str(new_dm) == correct_datman
 
 
+def test_kcni_get_xnat_subject_id_not_affected_by_field_translation():
+    settings = {
+        "STUDY": {
+            "ABC01": "ABCD"
+        }
+    }
+
+    pha = "ABC01_CMH_LEGPHA_0001_MR"
+    pha_ident = scanid.parse(pha, settings)
+    assert pha_ident.get_xnat_subject_id() == "ABC01_CMH_LEGPHA"
+
+    sub = "ABC01_CMH_12345678_01_SE02_MR"
+    sub_ident = scanid.parse(sub, settings)
+    assert sub_ident.get_xnat_subject_id() == "ABC01_CMH_12345678"
+
+
+def test_kcni_get_xnat_experiment_id_not_affected_by_field_translations():
+    settings = {
+        "STUDY": {
+            "ABC01": "ABCD"
+        }
+    }
+
+    pha = "ABC01_CMH_LEGPHA_0001_MR"
+    pha_ident = scanid.parse(pha, settings)
+    assert pha_ident.get_xnat_experiment_id() == pha
+
+    sub = "ABC01_CMH_12345678_01_SE02_MR"
+    sub_ident = scanid.parse(sub, settings)
+    assert sub_ident.get_xnat_experiment_id() == sub
+
+
 def test_is_scanid_garbage():
     assert not scanid.is_scanid("garbage")
 

--- a/tests/test_datman_scanid.py
+++ b/tests/test_datman_scanid.py
@@ -1,16 +1,15 @@
 import datman.scanid as scanid
 import pytest
 
+# Settings to use for parse() tests
 SETTINGS = {
     'ID_TYPE': 'KCNI',
-    'STUDY': 'DTI',
+    'STUDY': {
+        'DTI01': 'DTI'
+    },
     'SITE': {
         'CMH': 'UT1',
         'UTO': 'UT2'
-    },
-    'SUBJECT': {
-        '9(?P[0-9]{3,8})': 'H',
-        '8(?P[0-9]{3,8})': 'C'
     }
 }
 
@@ -65,14 +64,6 @@ def test_parse_good_kcni_PHA_scanid():
     assert ident.subject == 'PHA_LEG0001'
 
 
-# def test_parse_and_modify_kcni_scanid_when_given_settings():
-#     ident = scanid.parse('DTI01_UTO_9001_01_SE02_MR', settings=SETTINGS)
-#     assert ident.study == 'DTI'
-#     assert ident.site == 'UT2'
-#     assert ident.subject == 'H001'
-#     assert ident.timepoint == '01'
-#     assert ident.session == '02'
-
 def test_parses_datman_subject_id_as_datman_identifier():
     dm_subject = "DTI01_CMH_H001_01_02"
     ident = scanid.parse(dm_subject)
@@ -95,6 +86,25 @@ def test_parses_kcni_pha_id_as_kcni_identifier():
     kcni_pha = "DTI01_CMH_ABCPHA_0001_MR"
     ident = scanid.parse(kcni_pha)
     assert isinstance(ident, scanid.KCNIIdentifier)
+
+
+def test_parse_exception_when_kcni_subject_id_modality_missing():
+    with pytest.raises(scanid.ParseException):
+        scanid.parse("DTI01_CMH_H001_01_SE02")
+
+
+def test_kcni_pha_id_parsed_as_datman_when_modality_missing():
+    # This isn't the behavior we want but unless the user specifies convention
+    # we can't catch that these kcni pha ids are malformed. This test is
+    # just to document that this happens. It's a good thing if it starts to
+    # fail :)
+    ident = scanid.parse("DTI01_CMH_ABCPHA_0001")
+    assert not isinstance(ident, scanid.KCNIIdentifier)
+
+
+def test_parse_exception_when_kcni_session_malformed():
+    with pytest.raises(scanid.ParseException):
+        scanid.parse("DTI01_CMH_H001_01_02_MR")
 
 
 def test_is_scanid_garbage():

--- a/tests/test_dm_xnat_upload.py
+++ b/tests/test_dm_xnat_upload.py
@@ -45,9 +45,10 @@ class CheckFilesExist(unittest.TestCase):
         mock_resources_exist.return_value = True
         xnat_session = self.__get_xnat_session(self.session)
 
+
         # Run
         data_exists, resources_exist = upload.check_files_exist(
-            self.archive, xnat_session)
+            self.archive, xnat_session.experiments["STUDY_SITE_9999_01_01"])
 
         # Should raise an exception, so assertion is never reached
         assert data_exists
@@ -69,4 +70,4 @@ class CheckFilesExist(unittest.TestCase):
     def __get_xnat_session(self, text_file):
         with open(text_file, 'r') as session_data:
             xnat_session = eval(session_data.read())
-        return datman.xnat.Session(xnat_session)
+        return datman.xnat.XNATSubject(xnat_session)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,9 +4,11 @@ import unittest
 import logging
 
 import pytest
-from mock import patch
+from mock import patch, MagicMock
 
 import datman.utils as utils
+import datman.config
+from datman.exceptions import ParseException
 
 logging.disable(logging.CRITICAL)
 
@@ -60,3 +62,60 @@ class TestCheckDependencyConfigured(unittest.TestCase):
                                           shell_cmd=cmd,
                                           env_vars=variables)
         assert True
+
+
+class TestValidateSubjectID:
+
+    correct_id = "ANDT_CMH_0210_01_01"
+
+    @pytest.fixture(scope="module")
+    def dm_config(self):
+        config = MagicMock(spec=datman.config.config)
+
+        id_settings = {
+            "STUDY": {
+                "AND01": "ANDT"
+            }
+        }
+
+        tags = {
+            "ANDT": ["CMH"]
+        }
+
+        def get_key(key):
+            if key == "ID_MAP":
+                return id_settings
+            raise datman.config.UndefinedSetting
+
+        config.get_key.side_effect = get_key
+        config.get_study_tags.return_value = tags
+        return config
+
+    def test_valid_datman_id_accepted(self, dm_config):
+        ident = utils.validate_subject_id(self.correct_id, dm_config)
+        assert str(ident) == self.correct_id
+
+    def test_valid_kcni_id_accepted(self, dm_config):
+        valid_kcni = "AND01_CMH_0210_01_SE01_MR"
+        ident = utils.validate_subject_id(valid_kcni, dm_config)
+        assert str(ident) == self.correct_id
+
+    def test_catches_invalid_project_in_datman_id(self, dm_config):
+        with pytest.raises(ParseException):
+            bad_proj = "OPT01_CMH_0210_01_01"
+            utils.validate_subject_id(bad_proj, dm_config)
+
+    def test_catches_invalid_project_in_kcni_id(self, dm_config):
+        with pytest.raises(ParseException):
+            bad_proj = "OPT01_CMH_0210_01_SE01_MR"
+            utils.validate_subject_id(bad_proj, dm_config)
+
+    def test_catches_invalid_site_in_datman_id(self, dm_config):
+        with pytest.raises(ParseException):
+            bad_site = "ANDT_UFO_0406_01_01"
+            utils.validate_subject_id(bad_site, dm_config)
+
+    def test_catches_invalid_site_in_kcni_id(self, dm_config):
+        with pytest.raises(ParseException):
+            bad_site = "AND01_UFO_0408_01_SE01_MR"
+            utils.validate_subject_id(bad_site, dm_config)


### PR DESCRIPTION
This updates our core scripts that interact with XNAT (and dm_link) to allow zip files and xnat experiments to use the KCNI conventions. 

Note: I did **NOT** yet update dm_link_shared_ids.py, dm_xnat_project_overview.py, or track_scan_dates.py. The first needs a major overhaul (it still doesnt allow SENDEP linking to work right, and predates the dashboard) that I'd like to spend more time on and none of the three will be affected yet by our initial KCNI XNAT test cases. But I'll push that later since we need to move forward.

For studies and sites that we want to start migrating we'll have to update the settings file to add:

XNAT_CONVENTION: KCNI

and for study / site fields that need to be changed for KCNI we'll have to add an id map that matches this format:

ID_MAP:
  STUDY: {KCNI_STUDY: DATMAN_STUDY}
  SITE: {
      KCNI_SITE1: DM_SITE1, 
      ...
      KCNI_SITEN: DM_SITEN
  }