### PR TITLE
[FIX] Bug fixes from adding KCNI name support

### DIFF
--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -94,6 +94,7 @@ cfg = None
 DRYRUN = False
 db_ignore = False  # if True dont update the dashboard db
 wanted_tags = None
+XNAT_CONVENTION = 'DATMAN'
 
 
 def main():
@@ -102,6 +103,7 @@ def main():
     global DRYRUN
     global wanted_tags
     global db_ignore
+    global XNAT_CONVENTION
 
     arguments = docopt(__doc__)
     verbose = arguments['--verbose']
@@ -121,6 +123,11 @@ def main():
     configure_logging(study, quiet, verbose, debug)
 
     cfg = datman.config.config(study=study)
+
+    try:
+        XNAT_CONVENTION = cfg.get_key("XNAT_CONVENTION", site=ident.site)
+    except datman.config.UndefinedSetting:
+        pass
 
     # get the list of XNAT projects linked to the datman study
     xnat_projects = cfg.get_xnat_projects(study)
@@ -172,12 +179,7 @@ def configure_logging(study, quiet=None, verbose=None, debug=None):
 def collect_experiment(user_exper, xnat_projects, cfg):
     ident = datman.utils.validate_subject_id(user_exper, cfg)
 
-    try:
-        convention = cfg.get_key("XNAT_CONVENTION", site=ident.site)
-    except datman.config.UndefinedSetting:
-        convention = "DATMAN"
-
-    if convention == "KCNI":
+    if XNAT_CONVENTION == "KCNI":
         try:
             settings = cfg.get_key("ID_MAP")
         except datman.config.UndefinedSetting:
@@ -198,20 +200,25 @@ def collect_experiment(user_exper, xnat_projects, cfg):
 def collect_all_experiments(xnat_projects, config):
     experiments = []
 
+    if XNAT_CONVENTION == "DATMAN":
+        get_ids = xnat.get_subject_ids
+    else:
+        get_ids = xnat.get_experiment_ids
+
     # for each XNAT project send out URL request for list of session records
     # then validate and add (XNAT project, subject ID ['label']) to output list
     for project in xnat_projects:
-        for exper_id in xnat.get_experiment_ids(project):
+        for found_id in get_ids(project):
             try:
-                ident = datman.utils.validate_subject_id(exper_id, config)
+                ident = datman.utils.validate_subject_id(found_id, config)
             except datman.scanid.ParseException:
-                logger.error("Invalid experiment ID {} in project {}.".format(
-                    exper_id, project))
+                logger.error("Invalid ID {} in project {}.".format(
+                    found_id, project))
                 continue
             if (ident.session is None and not datman.scanid.is_phantom(ident)):
-                logger.error("Invalid experiment ID {} in project {}. Reason "
+                logger.error("Invalid ID {} in project {}. Reason "
                              "- Not a phantom, but missing session number"
-                             "".format(exper_id, project))
+                             "".format(found_id, project))
                 continue
             experiments.append((project, ident))
 

--- a/datman/scanid.py
+++ b/datman/scanid.py
@@ -114,7 +114,7 @@ class DatmanIdentifier(Identifier):
         return self.get_full_subjectid_with_timepoint_session()
 
     def get_xnat_experiment_id(self):
-        return self.xnat_subject_id()
+        return self.get_xnat_subject_id()
 
     def __repr__(self):
         return '<datman.scanid.DatmanIdentifier {}>'.format(self.__str__())

--- a/datman/scanid.py
+++ b/datman/scanid.py
@@ -68,7 +68,7 @@ class DatmanIdentifier(Identifier):
 
     scan_re = '(?P<id>(?P<study>[^_]+)_' \
               '(?P<site>[^_]+)_' \
-              '(?!.+PHA)(?P<subject>[^_]+)_' \
+              '(?P<subject>[^_]+)(?<!PHA)_' \
               '(?P<timepoint>[^_]+)_' \
               '(?!MR)(?!SE)(?P<session>[^_]+))'
 

--- a/tests/test_datman_scanid.py
+++ b/tests/test_datman_scanid.py
@@ -314,6 +314,60 @@ def test_parse_filename():
     assert description == 'description'
 
 
+def test_parse_filename_parses_when_tag_contains_pha():
+    ident, tag, series, description = scanid.parse_filename(
+        "CLZ_CMP_0000_01_01_PHABCD_11_FieldMap-2mm")
+
+    assert str(ident) == "CLZ_CMP_0000_01_01"
+    assert tag == "PHABCD"
+    assert series == "11"
+    assert description == "FieldMap-2mm"
+
+    _, tag, _, _ = scanid.parse_filename(
+        "CLZ_CMP_0000_01_01_ABCPHA_11_FieldMap-2mm")
+    assert tag == "ABCPHA"
+
+    _, tag, _, _ = scanid.parse_filename(
+        "CLZ_CMP_0000_01_01_ABCPHADEF_11_FieldMap-2mm")
+    assert tag == "ABCPHADEF"
+
+
+def test_parse_filename_parses_when_tag_contains_kcniish_MR_substring():
+    ident, tag, series, description = scanid.parse_filename(
+        "CLZ_CMP_0000_01_01_MRABC_11_FieldMap-2mm.nii.gz")
+
+    assert str(ident) == "CLZ_CMP_0000_01_01"
+    assert tag == "MRABC"
+    assert series == "11"
+    assert description == "FieldMap-2mm"
+
+    _, tag, _, _ = scanid.parse_filename(
+        "CLZ_CMP_0000_01_01_ABCMR_11_FieldMap-2mm")
+    assert tag == "ABCMR"
+
+    _, tag, _, _ = scanid.parse_filename(
+        "CLZ_CMP_0000_01_01_ABCMRDEF_11_FieldMap-2mm")
+    assert tag == "ABCMRDEF"
+
+
+def test_parse_filename_parses_when_tag_contains_kcniish_SE_substring():
+    ident, tag, series, description = scanid.parse_filename(
+        "CLZ_CMP_0000_01_01_SEABC_11_FieldMap-2mm.nii.gz")
+
+    assert str(ident) == "CLZ_CMP_0000_01_01"
+    assert tag == "SEABC"
+    assert series == "11"
+    assert description == "FieldMap-2mm"
+
+    _, tag, _, _ = scanid.parse_filename(
+        "CLZ_CMP_0000_01_01_ABCSE_11_FieldMap-2mm")
+    assert tag == "ABCSE"
+
+    _, tag, _, _ = scanid.parse_filename(
+        "CLZ_CMP_0000_01_01_ABCSEDEF_11_FieldMap-2mm")
+    assert tag == "ABCSEDEF"
+
+
 def test_parse_filename_PHA():
     ident, tag, series, description = scanid.parse_filename(
         'DTI_CMH_PHA_ADN0001_T1_02_description.nii.gz')


### PR DESCRIPTION
This fixes a problem where scan tags with the substring "PHA" were being flagged as invalid, and adds tests to catch this and other similar tag issues, and also reverts some of the changes made to xnat_fetch_sessions because I forgot that their server's experiments are not meaningful and it isn't really necessary to get them to switch to KCNI format.