### PR TITLE
[FIX] - Bug when SliceTiming length's don't match gold standard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ docs/_build/
 .nfs*
 .*swp
 .*.sw*
+process.yml

--- a/datman/header_checks.py
+++ b/datman/header_checks.py
@@ -79,7 +79,7 @@ def handle_diff(value, expected, tolerance=None):
     try:
         close_enough = isclose(value, expected, atol=tolerance)
     except ValueError:
-        close_enough = False
+        close_enough = bool_(False)
 
     if type(close_enough) != bool_:
         if all(close_enough):

--- a/tests/test_header_checks.py
+++ b/tests/test_header_checks.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import datman.header_checks as header_checks
+
+
+def test_handle_diff_returns_false_on_valueerror():
+
+    value = [1, 2, 3]
+    expected = [1, 2, 3, 5]
+    output = {'expected': [1, 2, 3, 5], 'actual': [1, 2, 3]}
+    assert header_checks.handle_diff(value, expected) == output

--- a/tests/test_header_checks.py
+++ b/tests/test_header_checks.py
@@ -2,7 +2,7 @@
 import datman.header_checks as header_checks
 
 
-def test_handle_diff_returns_false_on_valueerror():
+def test_handle_diff_returns_dict_on_valueerror():
 
     value = [1, 2, 3]
     expected = [1, 2, 3, 5]


### PR DESCRIPTION
Issue occurs because ValueError returns a Python False which isn't of type np.bool_(False).
