### PR TITLE
Bidsify fix - don't re-write dataset_description.json on every run

### DIFF
--- a/bin/bidsify.py
+++ b/bin/bidsify.py
@@ -531,8 +531,9 @@ def make_dataset_description(bids_dir, study_name, version):
 
     # Should be separate functionality
     p_dataset_desc = os.path.join(bids_dir, "dataset_description.json")
-    with open(p_dataset_desc, "w") as f:
-        json.dump({"Name": study_name, "BIDSVersion": version}, f, indent=3)
+    if not os.path.isfile(p_dataset_desc):
+        with open(p_dataset_desc, "w") as f:
+            json.dump({"Name": study_name, "BIDSVersion": version}, f, indent=3)
 
     return
 

--- a/tests/test_bidsify.py
+++ b/tests/test_bidsify.py
@@ -10,10 +10,12 @@ logging.disable(logging.CRITICAL)
 
 bidsify = importlib.import_module('bin.bidsify')
 
+
 class CheckBidsifyUpdateOnlyNewFiles(unittest.TestCase):
     """ Check that only new dataset_description files are created. If one
         exists, don't re-write it.
     """
+
     def setUp(self):
         # Create a temporary directory
         self.studyname = 'STUDYNAME'
@@ -22,13 +24,11 @@ class CheckBidsifyUpdateOnlyNewFiles(unittest.TestCase):
     def test_make_dataset_descriptor(self):
         # create dataset description
         bidsify.make_dataset_description(self.bidsdir.name, self.studyname, '1')
-
         dataset_description = os.path.join(self.bidsdir.name,
-                                            'dataset_description.json')
+                                           'dataset_description.json')
 
-        # test dataset_description creation                                            
+        # test dataset_description creation
         self.assertTrue(os.path.isfile(dataset_description))
-
         # cleanup
         os.remove(dataset_description)
 
@@ -36,12 +36,11 @@ class CheckBidsifyUpdateOnlyNewFiles(unittest.TestCase):
         # create dataset description
         bidsify.make_dataset_description(self.bidsdir.name, self.studyname, '1')
         bidsify.make_dataset_description(self.bidsdir.name, self.studyname, '2')
-        
         dataset_description = os.path.join(self.bidsdir.name,
-                                            'dataset_description.json')
+                                           'dataset_description.json')
 
         with open(dataset_description, 'r') as f:
             data = json.load(f)
-        
+
         # check that version 2 was skipped because 1 already exists
         self.assertEquals(data['BIDSVersion'], '1')

--- a/tests/test_bidsify.py
+++ b/tests/test_bidsify.py
@@ -1,0 +1,47 @@
+import unittest
+import logging
+import os
+import tempfile
+import importlib
+import json
+
+
+logging.disable(logging.CRITICAL)
+
+bidsify = importlib.import_module('bin.bidsify')
+
+class CheckBidsifyUpdateOnlyNewFiles(unittest.TestCase):
+    """ Check that only new dataset_description files are created. If one
+        exists, don't re-write it.
+    """
+    def setUp(self):
+        # Create a temporary directory
+        self.studyname = 'STUDYNAME'
+        self.bidsdir = tempfile.TemporaryDirectory()
+
+    def test_make_dataset_descriptor(self):
+        # create dataset description
+        bidsify.make_dataset_description(self.bidsdir.name, self.studyname, '1')
+
+        dataset_description = os.path.join(self.bidsdir.name,
+                                            'dataset_description.json')
+
+        # test dataset_description creation                                            
+        self.assertTrue(os.path.isfile(dataset_description))
+
+        # cleanup
+        os.remove(dataset_description)
+
+    def test_already_exists_dataset_description(self):
+        # create dataset description
+        bidsify.make_dataset_description(self.bidsdir.name, self.studyname, '1')
+        bidsify.make_dataset_description(self.bidsdir.name, self.studyname, '2')
+        
+        dataset_description = os.path.join(self.bidsdir.name,
+                                            'dataset_description.json')
+
+        with open(dataset_description, 'r') as f:
+            data = json.load(f)
+        
+        # check that version 2 was skipped because 1 already exists
+        self.assertEquals(data['BIDSVersion'], '1')


### PR DESCRIPTION
In bin/bidsify.py I just added a check to see if dataset_description.json exists, then don't re-write it if it does.

I also wrote a quick unittest for this for this addition.