### PR TITLE
[ENH] Allow the subid field to be modified between naming conventions

### DIFF
--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -227,6 +227,8 @@ def collect_all_experiments(config):
                                  "Reason - Not a phantom, but missing session "
                                  "number".format(exper_id, project))
                     continue
+                if ident.modality != "MR":
+                    continue
                 experiments.append((xnat, project, ident))
 
     return experiments

--- a/datman/scanid.py
+++ b/datman/scanid.py
@@ -102,6 +102,7 @@ class DatmanIdentifier(Identifier):
         self.site = match.group("site")
         self.subject = match.group("subject")
         self.timepoint = match.group("timepoint")
+        self.modality = 'MR'
         # Bug fix: spaces were being left after the session number leading to
         # broken file name
         self._session = match.group("session").strip()
@@ -142,14 +143,14 @@ class KCNIIdentifier(Identifier):
         "(?P<site>[A-Z]{3})_"
         "(?P<subject>[A-Z0-9]{4,8})_"
         "(?P<timepoint>[0-9]{2})_"
-        "SE(?P<session>[0-9]{2})_MR)"
+        "SE(?P<session>[0-9]{2})_(?P<modality>[A-Z]{2,4}))"
     )
 
     pha_re = (
         "(?P<id>(?P<study>[A-Z]{3}[0-9]{2})_"
         "(?P<site>[A-Z]{3})_"
         "(?P<pha_type>[A-Z]{3})PHA_"
-        "(?P<subject>[0-9]{4,6})_MR"
+        "(?P<subject>[0-9]{4,6})_(?P<modality>[A-Z]{2,4})"
         "(?P<timepoint>)(?P<session>))"
     )  # empty
 
@@ -177,6 +178,7 @@ class KCNIIdentifier(Identifier):
 
         self.timepoint = match.group("timepoint")
         self.session = match.group("session")
+        self.modality = match.group("modality")
 
     def get_xnat_subject_id(self):
         study = self._match_groups.group("study")

--- a/tests/test_datman_scanid.py
+++ b/tests/test_datman_scanid.py
@@ -152,6 +152,7 @@ def test_kcni_subid_field_is_modified_when_settings_given():
     ident = scanid.parse(kcni_id, settings=settings)
     assert ident.subject == '100004'
 
+
 def test_get_kcni_identifier_from_datman_str():
     kcni_ident = scanid.get_kcni_identifier("ABC01_UTO_12345678_01_02")
     assert isinstance(kcni_ident, scanid.KCNIIdentifier)

--- a/tests/test_datman_scanid.py
+++ b/tests/test_datman_scanid.py
@@ -451,6 +451,19 @@ def test_parse_filename_PHA_2():
     assert description == 'EPI-3x3x4xTR2'
 
 
+def test_kcni_id_with_non_mr_modality_is_valid():
+    ident = scanid.parse("ABC01_CMH_0001_01_SE01_EEG")
+    assert ident.modality == "EEG"
+
+
+def test_datman_ids_assigned_mr_modality():
+    ident = scanid.parse("ABC01_CMH_0001_01_01")
+    assert ident.modality == "MR"
+
+    ident = scanid.parse("ABC01_CMH_PHA_FBN0001")
+    assert ident.modality == "MR"
+
+
 def test_parse_filename_with_path():
     ident, tag, series, description = scanid.parse_filename(
         '/data/DTI_CMH_H001_01_01_T1_02_description.nii.gz')

--- a/tests/test_datman_scanid.py
+++ b/tests/test_datman_scanid.py
@@ -137,6 +137,21 @@ def test_kcni_site_field_is_modified_when_settings_given():
     assert str(ident) == 'ABC01_UT2_12345678_01_02'
 
 
+def test_kcni_subid_field_is_modified_when_settings_given():
+    settings = {
+        'SUBJECT': {
+            '^(100001|100002)->H\\1': '^H([0-9]+)->\\1'
+        }
+    }
+
+    kcni_id = 'PAC01_CMH_100001_01_SE01_MR'
+    ident = scanid.parse(kcni_id, settings=settings)
+    assert ident.subject == 'H100001'
+
+    kcni_id = 'PAC01_CMH_100004_01_SE03_MR'
+    ident = scanid.parse(kcni_id, settings=settings)
+    assert ident.subject == '100004'
+
 def test_get_kcni_identifier_from_datman_str():
     kcni_ident = scanid.get_kcni_identifier("ABC01_UTO_12345678_01_02")
     assert isinstance(kcni_ident, scanid.KCNIIdentifier)
@@ -190,6 +205,22 @@ def test_get_kcni_identifier_from_datman_with_field_changes():
     assert kcni_pha.orig_id == "AND01_UTO_FBNPHA_0023_MR"
 
 
+def test_get_kcni_identifier_correctly_reverses_subject_field_changes():
+    settings = {
+        'SUBJECT': {
+            '(100001|100002)->H\\1': '^H([0-9]+)->\\1'
+        }
+    }
+
+    kcni = scanid.get_kcni_identifier("ABC01_CMH_H100001_01_01", settings)
+    assert kcni.subject == "H100001"
+    assert kcni.orig_id == "ABC01_CMH_100001_01_SE01_MR"
+
+    kcni = scanid.get_kcni_identifier("ABC01_CMH_PHA_FBN201013", settings)
+    assert kcni.subject == "PHA_FBN201013"
+    assert kcni.orig_id == "ABC01_CMH_FBNPHA_201013_MR"
+
+
 def test_get_kcni_identifier_handles_already_kcni():
     kcni = "ABC01_UTO_12345678_01_SE02_MR"
     kcni_ident = scanid.parse(kcni)
@@ -231,10 +262,13 @@ def test_id_field_changes_correct_for_repeat_conversions():
         },
         'SITE': {
             'UTO': 'CMH'
+        },
+        'SUBJECT': {
+            '^(0001|0002)->H\\1': '^H([0-9]+)->\\1'
         }
     }
     correct_kcni = "AND01_UTO_0001_01_SE01_MR"
-    correct_datman = "ANDT_CMH_0001_01_01"
+    correct_datman = "ANDT_CMH_H0001_01_01"
 
     # KCNI to datman and back
     kcni_ident = scanid.parse(correct_kcni, settings)


### PR DESCRIPTION
To change the subject ID field of an ID add something formatted like the below example to the ID_MAP in a study's settings

```yml
ID_MAP:
    SUBJECT:
        'kcni_regex->replacement_str': 'dm_regex->replacement_str'
```

