### PR TITLE
[FIX] - fix bidsify match algorithm associating the wrong fieldmaps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: Set up installation and cache
           command: |
-            pyenv global 3.6.5
+            pyenv global 3.7.0
             pip install -e .[all]
       - save_cache:
           key: datman-v1-{{ .Branch }}-{{ checksum "setup.cfg" }}
@@ -63,7 +63,7 @@ jobs:
       - run:
           name: Run pytest and output junit xml for codecov
           command: |
-            pyenv global 3.6.5
+            pyenv global 3.7.0
             pytest tests/ --junitxml=tests/results/junit-{envname}.xml --cov . \
               --cov-report term-missing --cov-report xml
       - codecov/upload:
@@ -73,7 +73,7 @@ jobs:
   test_deploy_pypi:
     working_directory: /tmp/src/datman
     docker:
-      - image: "python:3.6.5"
+      - image: "python:3.7.0"
     steps:
       - checkout
       - run:
@@ -143,7 +143,7 @@ jobs:
   deployable:
     working_directory: /tmp/src/datman
     docker:
-      - image: "python:3.6.5"
+      - image: "python:3.7.0"
     steps:
       - run:
           command: |
@@ -152,7 +152,7 @@ jobs:
   deploy_pypi:
     working_directory: /tmp/src/datman
     docker:
-      - image: "python:3.6.5"
+      - image: "python:3.7.0"
     steps:
       - checkout
       - run:
@@ -185,7 +185,7 @@ jobs:
   build_docs:
     working_directory: /tmp/src/datman
     docker:
-      - image: "python:3.6.5"
+      - image: "python:3.7.0"
     steps:
       - restore_cache:
           keys:

--- a/bin/bidsify.py
+++ b/bin/bidsify.py
@@ -32,8 +32,8 @@ Info on allow-incomplete:
     Allow-incomplete should only ever be used if protocol deviations (from those
     specified in config) should be mapped to BIDS specification.
 
-    By default any incomplete fieldmaps WILL NOT be mapped into the BIDS specification
-    since they are by default deemed unusable
+    By default any incomplete fieldmaps WILL NOT be mapped into
+    the BIDS specification since they are by default deemed unusable
 """
 
 import os
@@ -284,6 +284,7 @@ class BIDSFile(object):
         else:
             return True
 
+
 @dataclass
 class FMapMatch:
     '''
@@ -299,7 +300,7 @@ class FMapMatch:
     def __post_init__(self, bidsfile):
         self.intended_for = bidsfile.get_spec("intended_for")
         self.match_key = bidsfile.get_spec("pair", "label")
-        self.remaining_matches = set(bidsfile.get_spec("pair","with"))
+        self.remaining_matches = set(bidsfile.get_spec("pair", "with"))
         self.fmaps.append(bidsfile)
 
 
@@ -316,19 +317,15 @@ def match_fmaps(series_list):
         results in a lone fmap
 
     """
-
-    def pair_with(x):
-        return x.get_spec("pair","with")
-
     def handle_incomplete(fmapmatch, fmapmatches):
         '''
         Handles case in which incomplete fmap list is found
         Uses global read-only variable ALLOW_INCOMPLETE
         '''
         logger.warning("Incomplete fieldmap matches for: "
-                f"{' '.join(fmapmatch.fmaps)}")
+                       f"{' '.join(fmapmatch.fmaps)}")
         logger.warning("Missing the following fields: "
-                f"{' '.join(fmapmatch.remaining_matches)}")
+                       f"{' '.join(fmapmatch.remaining_matches)}")
 
         if ALLOW_INCOMPLETE:
             logger.warning("Incomplete fmaps allowed with --allow-incomplete"
@@ -336,10 +333,9 @@ def match_fmaps(series_list):
             fmapmatches.append(stored)
         else:
             logger.warning("Incomplete fmaps not allowed! "
-                            "Use --allow-incomplete to allow for "
-                            "incomplete fmaps")
+                           "Use --allow-incomplete to allow for "
+                           "incomplete fmaps")
         return fmapmatches
-
 
     lone = []
     fmapmatches = []
@@ -369,7 +365,8 @@ def match_fmaps(series_list):
         matched_intention = stored.intended_for == s.get_spec("intended_for")
         if match_found and matched_intention:
             stored.fmaps.append(s)
-            stored.remaining_matches = stored.remaining_matches & set(s.get_spec("pair","with"))
+            stored.remaining_matches = stored.remaining_matches & set(
+                s.get_spec("pair", "with"))
 
             if not stored.remaining_matches:
                 fmapmatches.append(stored)
@@ -434,8 +431,6 @@ def get_tag_bids_spec(cfg, tag, site):
         return None
 
     return bids
-
-
 
 
 def get_first_series(series_list):
@@ -702,7 +697,8 @@ def process_subject(subject, cfg, be, bids_dir, rewrite):
 
         # Deal with reference scans
         if bids_dict.get('is_ref', False):
-            target_dict = get_tag_bids_spec(cfg, scan_list[i + 1].tag, series.site)
+            target_dict = get_tag_bids_spec(cfg, scan_list[i + 1].tag,
+                                            series.site)
             bids_dict.update({'task': target_dict['task']})
 
         bids_prefix = be.construct_bids_name(bids_dict)

--- a/bin/bidsify.py
+++ b/bin/bidsify.py
@@ -323,7 +323,7 @@ def match_fmaps(series_list):
         Uses global read-only variable ALLOW_INCOMPLETE
         '''
         logger.warning("Incomplete fieldmap matches for: "
-                       f"{' '.join(fmapmatch.fmaps)}")
+                f"{' '.join([str(f.series) for f in fmapmatch.fmaps])}")
         logger.warning("Missing the following fields: "
                        f"{' '.join(fmapmatch.remaining_matches)}")
 

--- a/bin/bidsify.py
+++ b/bin/bidsify.py
@@ -382,7 +382,8 @@ def match_fmaps(series_list):
         fmapmatches = handle_incomplete(stored, fmapmatches)
 
     match_list = [f.fmaps for f in fmapmatches]
-    match_list.append(lone)
+    if lone:
+        match_list.append(lone)
     return match_list
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,12 +14,11 @@ classifiers =
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering :: Image Recognition
     License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     docopt ~= 0.6.2
     matplotlib ~= 3.1.2


### PR DESCRIPTION
This is a bugfix for the bidsify BIDS conversion script.

### The issue

The way that bidsify works is by reading in assumptions for how fmaps should be matched within the datman config file using the `pair` key within the config yaml. However bidsify provides erroneous outputs when:

 I.e, the OPT dwi dir-AP TOPUP requires a pair (dir-PA), however for UT1 it does not - the b0 acts as the pair. However the OPTIMUM scanning sequence is such that the next fmap is a dir-PA meant for the faces task. As a result, bidsify erroneously pairs the dwi-AP topup with the fmri-PA topup. 

### The Fix

The fix is to include the `intendedfor` key in the matching protocol so we don't accidentally match dwi topup to func topup

In addition, the script has been updated to rely more on site-specific configuration if needed. Meaning if we expect a lone-DWI topup it should be explicitly specified in config. If not, bidsify will raise a logging error that can be over-ridden with `--allow-incomplete`. 


### Data consequences
1. OPTIMUM FACES task data should be re-processed (it should've failed for cases in which there is a single diffusion TOPUP)
2. Diffusion may have to be re-run if the BIDS data in the archive was used


### Comments needed for: Breaking 3.6 compatibility
One issue with this PR is that I used the Python3.7 dataclasses module to clean up the fmap matching algorithm. This breaks 3.6 compatibility, are we okay with this? If not, I can just refactor the FMapMatches dataclass to a regular class. 