### PR TITLE
[FIX] Update how derived scans are handled

### DIFF
--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -443,12 +443,6 @@ def process_scans(xnat, ident, xnat_experiment):
                            "exist".format(scan.series, xnat_experiment.name))
             continue
 
-        if scan.is_derived():
-            logger.warning("Series {} in session {} is a derived scan. "
-                           "Skipping.".format(
-                               scan.series, xnat_experiment.name))
-            continue
-
         if not scan.description:
             logger.error("Can't find description for series {} from session {}"
                          .format(scan.series, xnat_experiment.name))
@@ -462,6 +456,12 @@ def process_scans(xnat, ident, xnat_experiment):
                                                    xnat_experiment.name,
                                                    type(e).__name__,
                                                    e))
+            continue
+
+        if scan.is_derived():
+            logger.warning("Series {} in session {} is a derived scan. "
+                           "Skipping.".format(
+                               scan.series, xnat_experiment.name))
             continue
 
         if len(scan.tags) > 1 and not scan.multiecho:

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -1600,9 +1600,9 @@ class XNATScan(XNATObject):
         if not self.image_type:
             logger.warning(
                 f"Image type could not be found for series {self.series}. "
-                "Assuming it's derived."
+                "Assuming it's not derived."
             )
-            return True
+            return False
         if "DERIVED" in self.image_type:
             return True
         return False


### PR DESCRIPTION
TAY01 ASL scans weren't being pulled down because they didnt have an 'image_type' and were being assumed to be derived scans. This swaps the order of the checks so that we only check if something is derived if it matches a tag, and changes the default behavior to assume that those without image_types are **not** derived.