### PR TITLE
Added fix for SPN30/31 redcap issues

### DIFF
--- a/bin/dm_redcap_scan_completed.py
+++ b/bin/dm_redcap_scan_completed.py
@@ -150,6 +150,11 @@ def parse_id(subject_id):
         # KCNI site and study fields match the datman fields.
         return ident
 
+    # Avoid modifying the ID if the study happens to match the destination
+    # study, otherwise duplicate records may be made
+    if 'Study' in id_map and ident.study in id_map['Study'].values():
+        return ident
+
     return datman.scanid.parse(subject_id, settings=id_map)
 
 

--- a/tests/test_dm_redcap_scan_completed.py
+++ b/tests/test_dm_redcap_scan_completed.py
@@ -51,6 +51,25 @@ class TestParseID:
         with pytest.raises(ParseException):
             rc.parse_id(bad_id)
 
+    def test_sites_dont_get_modified_if_study_field_unchanged(self, config):
+        def mock_get_key(key):
+            if key != 'IdMap':
+                raise datman.config.UndefinedSetting
+            settings = {
+                'Study': {
+                    'SPN31': 'SPN30'
+                },
+                'Site': {
+                    'CMH': 'CMP'
+                }
+            }
+            return settings
+        config.get_key.side_effect = mock_get_key
+        rc.cfg = config
+
+        parsed = rc.parse_id('SPN30_CMH_0001_01_SE01_MR')
+        assert str(parsed) == 'SPN30_CMH_0001_01_01'
+
     @pytest.fixture
     def config(self):
         conf = Mock(spec=datman.config.config)

--- a/tests/test_dm_redcap_scan_completed.py
+++ b/tests/test_dm_redcap_scan_completed.py
@@ -70,6 +70,26 @@ class TestParseID:
         parsed = rc.parse_id('SPN30_CMH_0001_01_SE01_MR')
         assert str(parsed) == 'SPN30_CMH_0001_01_01'
 
+    def test_sites_do_get_modified_when_study_code_is_not_matched(self, config):
+        def mock_get_key(key):
+            if key != 'IdMap':
+                raise datman.config.UndefinedSetting
+            settings = {
+                'Study': {
+                    'XYZ02': 'ABC01'
+                },
+                'Site': {
+                    'CMH': 'CMP'
+                }
+            }
+            return settings
+        config.get_key.side_effect = mock_get_key
+        rc.cfg = config
+
+        parsed = rc.parse_id('XYZ03_CMH_0001_01_SE01_MR')
+
+        assert str(parsed) == 'XYZ03_CMP_0001_01_01'
+
     @pytest.fixture
     def config(self):
         conf = Mock(spec=datman.config.config)


### PR DESCRIPTION
When pulling redcap records from SPN30/31 constant 'duplicate record' exceptions were happening because SPN31 config causes the SPN30_CMH IDs to be read as SPN30_CMP and the script attempts to readd the record. This will stop the bad ID conversions from happening so records can be added correctly. 