### PR TITLE
Wrapped dcm2bids import in exception message for better messaging

### DIFF
--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -63,11 +63,17 @@ import datman.scan
 import datman.scanid
 import datman.exceptions
 
-from dcm2bids import Dcm2bids
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 
 logger = logging.getLogger(os.path.basename(__file__))
 
+try:
+    from dcm2bids import Dcm2bids
+except ImportError:
+    dcm2bids_found = False
+    logger.error("Dcm2Bids not found, proceeding without it.")
+else:
+    dcm2bids_found = True
 
 SERVERS = {}
 SERVER_OVERRIDE = None
@@ -240,6 +246,10 @@ def main():
 
     for xnat, project, experiment in experiments:
         if (use_dcm2bids):
+            if not dcm2bids_found:
+                logger.error("Failed to find Dcm2Bids to import while using "
+                             "--use-dcm2bids flag. Exiting dcm2bids conversion")
+                return
             dcm2bids_opt = Dcm2BidsConfig(keep_dcm=args.keep_dcm,
                                           dcm2bids_config=args.dcm_config,
                                           bids_out=args.bids_out,

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -247,8 +247,9 @@ def main():
     for xnat, project, experiment in experiments:
         if (use_dcm2bids):
             if not dcm2bids_found:
-                logger.error("Failed to find Dcm2Bids to import while using "
-                             "--use-dcm2bids flag. Exiting dcm2bids conversion")
+                logger.error("Failed to import Dcm2Bids. Ensure that "
+                             "Dcm2Bids is installed when using the "
+                             "--use-dcm2bids flag.  Exiting conversion")
                 return
             dcm2bids_opt = Dcm2BidsConfig(keep_dcm=args.keep_dcm,
                                           dcm2bids_config=args.dcm_config,


### PR DESCRIPTION
Quick fix for wrapping dcm2bids import in an exception in case the user does not want to import it for using regular dm_xnat_extract, or is not able to find it while using the `--use-dcm2bids` flag. 

In the future I will look into adding a more graceful approach such as [the current dashboard imports](https://github.com/TIGRLab/datman/blob/master/datman/dashboard.py#L21) but this is just a quick fix for now.