### PR TITLE
FIX: Fix/ea handle quit code

### DIFF
--- a/bin/dm_parse_ea.py
+++ b/bin/dm_parse_ea.py
@@ -111,6 +111,12 @@ def clean_logfile(log_file):
         logger.warning(f"Removed {indices_dropped} rating registered "
                        "followed scanner responses")
 
+    last_entry = log_file.loc[log_file.shape[0] - 1]
+    if last_entry['Event Type'] == 'Quit':
+        log_file = log_file.drop(last_entry)
+        logger.error("Quit signal detected in log file! "
+                     "Task may have ended early!")
+
     return log_file
 
 

--- a/bin/dm_parse_ea.py
+++ b/bin/dm_parse_ea.py
@@ -110,9 +110,10 @@ def clean_logfile(log_file):
         logger.warning(f"Removed {indices_dropped} rating registered "
                        "followed scanner responses")
 
-    last_entry = log_file.loc[log_file.shape[0] - 1]
+    last_ind = log_file.shape[0] - 1
+    last_entry = log_file.loc[last_ind]
     if last_entry['Event Type'] == 'Quit':
-        log_file = log_file.drop(last_entry)
+        log_file = log_file.drop(last_ind)
         logger.error("Quit signal detected in log file! "
                      "Task may have ended early!")
 

--- a/bin/dm_parse_ea.py
+++ b/bin/dm_parse_ea.py
@@ -33,9 +33,8 @@ from docopt import docopt
 import datman.config
 import datman.scanid
 
-logging.basicConfig(
-    level=logging.WARN, format="[%(name)s] %(levelname)s: %(message)s"
-)
+logging.basicConfig(level=logging.WARN,
+                    format="[%(name)s] %(levelname)s: %(message)s")
 logger = logging.getLogger(os.path.basename(__file__))
 
 
@@ -125,26 +124,19 @@ def get_blocks(log, vid_info):
     # identifies the video trial types (as opposed to button press events etc)
     mask = ["vid" in log["Code"][i] for i in range(0, log.shape[0])]
 
-    df = pd.DataFrame(
-        {
-            "onset": log.loc[mask]["Time"],
-            "trial_type": log.loc[mask]["Event Type"],
-            "movie_name": log.loc[mask]["Code"],
-        }
-    )
+    df = pd.DataFrame({
+        "onset": log.loc[mask]["Time"],
+        "trial_type": log.loc[mask]["Event Type"],
+        "movie_name": log.loc[mask]["Code"],
+    })
 
-    df["trial_type"] = df["movie_name"].apply(
-        lambda x: "circle_block" if "cvid" in x else "EA_block"
-    )
-    df["duration"] = df["movie_name"].apply(
-        lambda x: int(vid_info[x]["duration"]) * 10000
-        if x in vid_info
-        else pd.NA
-    )
+    df["trial_type"] = df["movie_name"].apply(lambda x: "circle_block"
+                                              if "cvid" in x else "EA_block")
+    df["duration"] = df["movie_name"].apply(lambda x: int(vid_info[x][
+        "duration"]) * 10000 if x in vid_info else pd.NA)
 
-    df["stim_file"] = df["movie_name"].apply(
-        lambda x: vid_info[x]["stim_file"] if x in vid_info else pd.NA
-    )
+    df["stim_file"] = df["movie_name"].apply(lambda x: vid_info[x]["stim_file"]
+                                             if x in vid_info else pd.NA)
     df["end"] = df["onset"] + df["duration"]
     return df
 
@@ -171,14 +163,12 @@ def get_ratings(log):
 
     rating_mask = ["rating" in log["Code"][i] for i in range(0, log.shape[0])]
 
-    df = pd.DataFrame(
-        {
-            "onset": log["Time"].loc[rating_mask].values,
-            "participant_value": log.loc[rating_mask]["Code"].values,
-            "event_type": "button_press",
-            "duration": 0,
-        }
-    )
+    df = pd.DataFrame({
+        "onset": log["Time"].loc[rating_mask].values,
+        "participant_value": log.loc[rating_mask]["Code"].values,
+        "event_type": "button_press",
+        "duration": 0,
+    })
 
     # Pull rating value from formatted string
     df["participant_value"] = df["participant_value"].str.strip().str[-1]
@@ -194,11 +184,9 @@ def combine_dfs(blocks, ratings):
     combo["space_b4_prev"] = combo["onset"].diff(periods=1)
     combo["first_button_press"] = combo["duration"].shift() > 0
     combo2 = combo.drop(
-        combo[
-            (combo["space_b4_prev"] < 1000)
-            & (combo["first_button_press"] == True)
-        ].index
-    ).reset_index(drop=True)
+        combo[(combo["space_b4_prev"] < 1000)
+              & (combo["first_button_press"] == True)].index).reset_index(
+                  drop=True)
 
     mask = pd.notnull(combo2["trial_type"])
 
@@ -220,19 +208,15 @@ def combine_dfs(blocks, ratings):
 
     block_start_locs = combo2[mask].index.values
 
-    combo2["rating_duration"] = combo2["onset"].shift(-1) - combo2[
-        "onset"
-    ].where(
-        mask == False
-    )  # noqa: E712
+    combo2["rating_duration"] = combo2["onset"].shift(
+        -1) - combo2["onset"].where(mask == False)  # noqa: E712
 
     for i in range(len(block_start_locs)):
         if block_start_locs[i] != 0:
 
             combo2.rating_duration[block_start_locs[i - 1]] = (
-                combo2.end[block_start_locs[i - 1]]
-                - combo2.onset[block_start_locs[i - 1]]
-            )
+                combo2.end[block_start_locs[i - 1]] -
+                combo2.onset[block_start_locs[i - 1]])
 
     for i in block_start_locs:
         new_row = {
@@ -244,9 +228,8 @@ def combine_dfs(blocks, ratings):
         }
         combo2 = combo2.append(new_row, ignore_index=True)
 
-    combo2 = combo2.sort_values(
-        by=["onset", "event_type"], na_position="first"
-    ).reset_index(drop=True)
+    combo2 = combo2.sort_values(by=["onset", "event_type"],
+                                na_position="first").reset_index(drop=True)
 
     return combo2
 
@@ -261,26 +244,22 @@ def block_scores(ratings_dict, combo):
 
     mask = pd.notnull(combo["trial_type"])
     block_start_locs = combo[mask].index.values
-    block_start_locs = np.append(
-        block_start_locs, combo.tail(1).index.values, axis=None
-    )
+    block_start_locs = np.append(block_start_locs,
+                                 combo.tail(1).index.values,
+                                 axis=None)
 
     for idx in range(1, len(block_start_locs)):
 
         block_start = combo.onset[block_start_locs[idx - 1]]
         block_end = combo.end[block_start_locs[idx - 1]]
 
-        block = combo.iloc[block_start_locs[idx - 1] : block_start_locs[idx]][
-            pd.notnull(combo.event_type)
-        ]
+        block = combo.iloc[block_start_locs[idx - 1]:block_start_locs[idx]][
+            pd.notnull(combo.event_type)]
         block_name = (
-            combo.movie_name.iloc[
-                block_start_locs[idx - 1] : block_start_locs[idx]
-            ][pd.notnull(combo.movie_name)]
-            .reset_index(drop=True)
-            .astype(str)
-            .get(0)
-        )
+            combo.movie_name.iloc[block_start_locs[idx -
+                                                   1]:block_start_locs[idx]]
+            [pd.notnull(
+                combo.movie_name)].reset_index(drop=True).astype(str).get(0))
 
         gold = get_series_standard(ratings_dict, block_name)
 
@@ -298,18 +277,16 @@ def block_scores(ratings_dict, combo):
             )
 
         if len(gold) < len(interval):
-            interval = interval[: len(gold)]
+            interval = interval[:len(gold)]
             logger.warning(
                 "gold standard is shorter than the number of pt "
-                f"ratings. pt ratings truncated, block: {block_name}",
-            )
+                f"ratings. pt ratings truncated, block: {block_name}", )
 
         if len(interval) < len(gold):
-            gold = gold[: len(interval)]
+            gold = gold[:len(interval)]
             logger.warning(
                 "number of pt ratings is shorter than the number "
-                f"of gold std, gold std truncated, block: {block_name}",
-            )
+                f"of gold std, gold std truncated, block: {block_name}", )
 
         # this is to append for the remaining fraction of a second (so that
         # the loop goes to the end i guess...)- maybe i dont need to do this
@@ -319,10 +296,8 @@ def block_scores(ratings_dict, combo):
         for x in range(len(interval) - 1):
             start = interval[x]
             end = interval[x + 1]
-            sub_block = block[
-                block["onset"].between(start, end)
-                | block["onset"].between(start, end).shift(-1)
-            ]
+            sub_block = block[block["onset"].between(start, end)
+                              | block["onset"].between(start, end).shift(-1)]
             block_length = end - start
             if len(sub_block) != 0:
                 ratings = []
@@ -338,17 +313,15 @@ def block_scores(ratings_dict, combo):
                             numerator = 999999  # add error here
 
                     if row.event_type != "last_row":
-                        ratings.append(
-                            {
-                                "start": start,
-                                "end": end,
-                                "row_time": row.rating_duration,
-                                "row_start": row.onset,
-                                "block_length": block_length,
-                                "rating": row.participant_value,
-                                "time_held": numerator,
-                            }
-                        )
+                        ratings.append({
+                            "start": start,
+                            "end": end,
+                            "row_time": row.rating_duration,
+                            "row_start": row.onset,
+                            "block_length": block_length,
+                            "rating": row.participant_value,
+                            "time_held": numerator,
+                        })
 
                         nums = [float(d["rating"]) for d in ratings]
 
@@ -364,29 +337,25 @@ def block_scores(ratings_dict, combo):
                 avg = last_row
 
             two_s_avg.append(float(avg))
-            list_of_rows.append(
-                {
-                    "event_type": "running_avg",
-                    "participant_value": float(avg),
-                    "onset": start,
-                    "duration": end - start,
-                    "gold_std": gold[x],
-                }
-            )
+            list_of_rows.append({
+                "event_type": "running_avg",
+                "participant_value": float(avg),
+                "onset": start,
+                "duration": end - start,
+                "gold_std": gold[x],
+            })
 
         n_button_press = len(block[block.event_type == "button_press"].index)
         block_score = np.corrcoef(gold, two_s_avg)[1][0]
         key = str(block_name)
-        summary_vals.update(
-            {
-                key: {
-                    "n_button_press": int(n_button_press),
-                    "block_score": block_score,
-                    "onset": block_start,
-                    "duration": block_end - block_start,
-                }
+        summary_vals.update({
+            key: {
+                "n_button_press": int(n_button_press),
+                "block_score": block_score,
+                "onset": block_start,
+                "duration": block_end - block_start,
             }
-        )
+        })
 
     return list_of_rows, summary_vals
 
@@ -396,17 +365,13 @@ def outputs_exist(log_file, output_path):
         return False
 
     if os.path.getmtime(output_path) < os.path.getmtime(log_file):
-        logger.error(
-            "Output file is less recently modified than its task file"
-            f" {log_file}. Output will be deleted and regenerated."
-        )
+        logger.error("Output file is less recently modified than its task file"
+                     f" {log_file}. Output will be deleted and regenerated.")
         try:
             os.remove(output_path)
         except Exception as e:
-            logger.error(
-                f"Failed to remove output file {output_path}, cannot "
-                f"regenerate. Reason - {e}"
-            )
+            logger.error(f"Failed to remove output file {output_path}, cannot "
+                         f"regenerate. Reason - {e}")
             return True
         return False
 
@@ -421,10 +386,8 @@ def get_output_path(ident, log_file, dest_dir):
 
     part = re.findall(r"((?:part|RUN)\d).log", log_file)
     if not part:
-        logger.error(
-            f"Can't detect which part task file {log_file} "
-            "corresponds to. Ignoring file."
-        )
+        logger.error(f"Can't detect which part task file {log_file} "
+                     "corresponds to. Ignoring file.")
         return
     else:
         part = part[0]
@@ -443,11 +406,11 @@ def parse_task(ident, log_file, dest_dir, length_file, timing_file):
         log = read_in_logfile(log_file)
         log_cleaned = clean_logfile(log)
     except Exception as e:
+        logger.error(f"Error raised with message: {e}")
         logger.error(
-            f"Cannot parse {log_file}! File maybe corrupted! Skipping"
-        )
+            f"Cannot parse {log_file}! File maybe corrupted! Skipping")
         return
-    
+
     vid_in = pd.read_csv(length_file)
     vid_info = format_vid_info(vid_in)
     blocks = get_blocks(log_cleaned, vid_info)
@@ -460,20 +423,17 @@ def parse_task(ident, log_file, dest_dir, length_file, timing_file):
     combo["block_score"] = np.nan
     combo["n_button_press"] = np.nan
 
-    combo = (
-        combo.append(two_s_chunks).sort_values("onset").reset_index(drop=True)
-    )
+    combo = (combo.append(two_s_chunks).sort_values("onset").reset_index(
+        drop=True))
 
     test = combo.loc[pd.notnull(combo["stim_file"])]
 
     # adds in scores, button presses, etc
     for index, row in test.iterrows():
-        combo.loc[index, "block_score"] = scores[row["movie_name"]][
-            "block_score"
-        ]
-        combo.loc[index, "n_button_press"] = scores[row["movie_name"]][
-            "n_button_press"
-        ]
+        combo.loc[index,
+                  "block_score"] = scores[row["movie_name"]]["block_score"]
+        combo.loc[index, "n_button_press"] = scores[
+            row["movie_name"]]["n_button_press"]
         combo.loc[index, "event_type"] = "block_summary"
 
     cols = [
@@ -539,19 +499,16 @@ def main():
             ident = datman.scanid.parse(experiment)
         except datman.scanid.ParseException:
             logger.error(
-                f"Skipping task folder with malformed ID {experiment}"
-            )
+                f"Skipping task folder with malformed ID {experiment}")
             continue
 
         exp_task_dir = os.path.join(task_path, experiment)
-        sub_nii = os.path.join(
-            nii_path, ident.get_full_subjectid_with_timepoint()
-        )
+        sub_nii = os.path.join(nii_path,
+                               ident.get_full_subjectid_with_timepoint())
 
         if not os.path.isdir(exp_task_dir):
             logger.warning(
-                f"{experiment} has no task directory {exp_task_dir}, skipping"
-            )
+                f"{experiment} has no task directory {exp_task_dir}, skipping")
             continue
 
         for task_file in glob.glob(os.path.join(exp_task_dir, task_regex)):


### PR DESCRIPTION
Ran into a special case where there was a "Quit" code at the end of the EA task file with `nan` entries causing a bunch of type errors. Fix is to remove the index associated with "Quit".

1. Refactor to remove code duplication: ce60dc3a05db6d51d551c56012018ac9c2d07fdf
2. Add check to handle quit signal: c46048b43d255624acf82eeb5ffd1b293f503f77, 407a06d68a6701ec7d23b135ade6b7a491e667c1
3. Apply code formatting and display error message on exception: 1e81ac4166f5e441d26e35c9ba59876a3e192684