### PR TITLE
[FIX] Fixed xnat_to_bids ignoring --clobber before pulling data

### DIFF
--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -433,6 +433,16 @@ def xnat_to_bids(xnat, project, ident, dcm2bids_opt):
                      "{}: {}".format(experiment_label, type(e).__name__, e))
         return
 
+    bids_dest = os.path.join(dcm2bids_opt.bids_out, 'sub-' + bids_sub, 'ses-' + bids_ses)
+    if (os.path.exists(bids_dest)):
+        logger.info("{} already exists".format(bids_dest))
+
+        if (dcm2bids_opt.clobber):
+            logger.info("Overwriting because of --clobber")
+        else:
+            logger.info("(Use --clobber to overwrite)")
+            return
+
     with datman.utils.make_temp_directory(prefix='xnat_to_bids_') as tempdir:
         for scan in xnat_experiment.scans:
             scan_temp = get_dicom_archive_from_xnat(xnat, scan, tempdir)

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -434,7 +434,7 @@ def xnat_to_bids(xnat, project, ident, dcm2bids_opt):
         return
 
     bids_dest = os.path.join(dcm2bids_opt.bids_out,
-                            'sub-' + bids_sub, 'ses-' + bids_ses)
+                             'sub-' + bids_sub, 'ses-' + bids_ses)
     if (os.path.exists(bids_dest)):
         logger.info("{} already exists".format(bids_dest))
 

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -446,6 +446,17 @@ def xnat_to_bids(xnat, project, ident, dcm2bids_opt):
 
     with datman.utils.make_temp_directory(prefix='xnat_to_bids_') as tempdir:
         for scan in xnat_experiment.scans:
+            if not scan.raw_dicoms_exist():
+                logger.warning("Skipping series {} for session {}."
+                               "No RAW dicoms exist"
+                               "".format(scan.series, xnat_experiment.name))
+                continue
+
+            if not scan.description:
+                logger.error("Can't find description for"
+                             " series {} from session {}"
+                             "".format(scan.series, xnat_experiment.name))
+                continue
             scan_temp = get_dicom_archive_from_xnat(xnat, scan, tempdir)
             if not scan_temp:
                 logger.error("Failed getting series {} for experiment {} "

--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -433,7 +433,8 @@ def xnat_to_bids(xnat, project, ident, dcm2bids_opt):
                      "{}: {}".format(experiment_label, type(e).__name__, e))
         return
 
-    bids_dest = os.path.join(dcm2bids_opt.bids_out, 'sub-' + bids_sub, 'ses-' + bids_ses)
+    bids_dest = os.path.join(dcm2bids_opt.bids_out,
+                            'sub-' + bids_sub, 'ses-' + bids_ses)
     if (os.path.exists(bids_dest)):
         logger.info("{} already exists".format(bids_dest))
 


### PR DESCRIPTION
Small fix with behavior of `xnat_to_bids`: Before it would download the zip from xnat before checking if the subject was already converted to bids in the destination folder, which would add unnecessary time to batch runs. Now it will check the destination folder for the subject before attempting to pull their data (unless the --clobber tag is used of course)

I'm also working on a doc page to illustrate how to use `xnat_to_bids`, but with this fix we can safely put `dm_xnat_extract.py $STUDY --use-dcm2bids` in nightly scripts as it will skip over converted subjects properly.