### PR TITLE
[FIX] qc_report consuming all db connections + queue jobs timing out

### DIFF
--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -40,7 +40,7 @@ import datman.utils
 import datman.scan
 import datman.dashboard
 import datman.metrics
-from datman.exceptions import InputException, ParseException
+from datman.exceptions import InputException, ParseException, QCException
 
 logging.basicConfig(level=logging.WARN,
                     format="[%(name)s] %(levelname)s: %(message)s")
@@ -241,6 +241,9 @@ def needs_qc(subject_id, config):
             logger.error(
                 f"Invalid qc type {scan.qc_type} found for {nii.file_name}"
             )
+            continue
+        except QCException as e:
+            logger.error(e)
             continue
 
         if not metric.exists():

--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -149,7 +149,8 @@ def submit_subjects(config):
 
         logger.info(f"Submitting QC job for {subject}.")
         datman.utils.submit_job(
-            command, job_name, "/tmp", system=config.system
+            command, job_name, "/tmp", system=config.system,
+            argslist="--mem=3G"
         )
 
 

--- a/datman/dashboard.py
+++ b/datman/dashboard.py
@@ -123,6 +123,25 @@ def filename_required(f):
     return decorated_function
 
 
+def release_db(f):
+    """This decorator ensures that transactions are ended after exit.
+
+    Read operations on the database open a transaction. This transaction
+    isnt terminated until a rollback or commit happens or until the
+    script terminates. This decorator ensures that database connections don't
+    get stuck in the 'idle in transaction' state while waiting for long
+    running work to be completed by a script.
+    """
+
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        result = f(*args, **kwargs)
+        queries.db.session.rollback()
+        return result
+
+    return decorated_function
+
+
 @dashboard_required
 def set_study_status(name, is_open):
     studies = queries.get_studies(name=name)

--- a/datman/metrics.py
+++ b/datman/metrics.py
@@ -351,9 +351,9 @@ class QAPHAMetrics(MetricDTI):
             # SNRPlots-PAR.jpg missing
             "StdPlotsHist-PAR.jpg": QCOutput(9),
             "Section2.3.1_SNR_ADC.csv": None,
-            "Section2.3.2_B0DistortionRation.csv": None,  # missing
+            "Section2.3.2_B0DistortionRatio.csv": None,
             "Section2.3.3_EddyCurrentDistortions.csv": None,
-            "Section2.3.4_AveNyqRation.csv": None,  # missing
+            "Section2.3.4_AveNyqRatio.csv": None,
             "Section2.3.5_FAvalues.csv": None
         }
     }


### PR DESCRIPTION
After the move to the new dynamic QC pages tons of QC jobs were submitted to generate metrics that were (for some reason) missing from the QC folders. This large number of jobs consumed all available database connections. This was because SQLAlchemy opens a transaction whenever database reads happen and doesn't close them until the next commit/rollback. dm_qc_report was reading some values from the database prior to generating metrics, which left connections open 'idle in transaction' for 30+ minutes while the metrics were created.

This PR:

- Adds a decorator that will ensure a transaction ends after a function it wraps exits (8e248ce455b2a2832fa3d58fbcb763e39a92351f)
- Refactors dm_qc_report a bit to ensure all transactions are closed before metric generation happens (20a3c5f0aeef6948e3aba93393445def1870bfb9)
- Fixes a bug where one DTI file missing its bvec/bval file could crash the whole script (a0d76048401b5f1696f2ca71be3f5d1082b293c1)
- Increases the memory requested for queue jobs, as it turns out that newer studies have data large enough to require more than 1G of memory per job (88c2bfbcd36716392832a9e5229c19dbf7a5f026)
