### PR TITLE
[FIX] address dm_qc_report edge case + db update issues

### DIFF
--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -316,7 +316,7 @@ def make_metrics(subject, config):
             logger.error(f"Failed to generate metrics for {nii.file_name}. "
                          f"Reason - {e}")
 
-        update_dashboard(nii.file_name, ignored_fields, field_tolerances)
+        update_dashboard(nii.path, ignored_fields, field_tolerances)
         make_scan_metrics(metric)
 
 
@@ -389,7 +389,7 @@ def add_scan_length(nii_path, scan):
     try:
         data = nib.load(nii_path)
     except Exception as e:
-        logger.debug(f"Failed to read scan length for {nii_path}. Reason "
+        logger.error(f"Failed to read scan length for {nii_path}. Reason "
                      f"- {e}")
         return
 

--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -336,6 +336,7 @@ def update_dashboard(nii_path, header_ignore=None, header_tolerance=None):
     if REMAKE or db_record.is_outdated_header_diffs():
         try:
             db_record.update_header_diffs(
+                standard=db_record.gold_standards[0],
                 ignore=header_ignore, tolerance=header_tolerance)
         except Exception as e:
             logger.error(

--- a/datman/metrics.py
+++ b/datman/metrics.py
@@ -46,7 +46,7 @@ class Metric(ABC):
                 return
             orig = self.read_json()
         else:
-            orig = {}
+            orig = None
 
         manifest = self.make_manifest()
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -48,6 +48,20 @@ class TestMetric:
         assert mock_fh.call_count == 1
         assert str(mock_fh.call_args) == expected_call
 
+    @patch("datman.metrics.open")
+    @patch("os.path.exists")
+    def test_manifest_written_even_if_no_imgs_to_display(
+            self, mock_exists, mock_fh):
+        pha_anat = datman.metrics.AnatPHAMetrics(
+            self.nii_input, self.output_dir)
+        manifest = pha_anat.manifest_path
+        mock_exists.side_effect = lambda x: x != manifest
+        pha_anat.write_manifest()
+
+        expected_call = f"call('{manifest}', 'w')"
+        assert mock_fh.call_count == 1
+        assert str(mock_fh.call_args) == expected_call
+
     @patch("os.path.exists")
     def test_exists_is_false_when_at_least_one_file_missing(self, mock_exist):
         fmri = datman.metrics.FMRIMetrics(self.nii_input, self.output_dir)


### PR DESCRIPTION
This PR addresses three bugs in dm_qc_report.py

- Phantoms with anat data were resubmitting to the queue every night, because their manifest file contained only an empty dict, leading to the file write being skipped. This led these phantoms to appear as though they had not completely generated. (2861e755275e0f413c4730e098839d32ea7160aa)
- Scan lengths were not being added to the database because a relative path was being given to update_dashboard and the files couldnt be found. The error was also being missed in the logs, because the log level was debug. (0e195e3f6c901c8f236afd00ef12352a86173b8a)
- Header diffs werent updating when a new gold standard is found, because the new standard was not being provided to the function call. This led to some sessions appearing as though they had not fully generated and repeatedly resubmitting to the queue. (8c8317d0192292051d5278188cdbe6a5b1f79e43)
