### PR TITLE
[FIX] Stop dm_xnat_extract from crashing on malformed series 'numbers'

### DIFF
--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -707,6 +707,12 @@ def make_series_exporters(session, scan, tag_config, config, wanted_tags=None,
     """
     exporters = []
     for idx, tag in enumerate(scan.tags):
+        try:
+            _ = datman.scanid.parse_filename(scan.names[idx])
+        except datman.scanid.ParseException:
+            logger.error(f"Invalid filename {scan.names[idx]}, ignoring scan.")
+            continue
+
         if wanted_tags and tag not in wanted_tags:
             continue
 

--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -632,6 +632,10 @@ class DBExporter(SessionExporter):
             session = datman.dashboard.get_session(self.ident)
         except DashboardException:
             return False
+        except ParseException:
+            logger.error(
+                f"Session name {self.ident} is not datman format. Ignoring.")
+            return True
 
         if not session:
             return False
@@ -641,6 +645,10 @@ class DBExporter(SessionExporter):
                 scan = datman.dashboard.get_scan(name)
             except DashboardException:
                 return False
+            except ParseException:
+                logger.error(
+                    f"Scan name {name} is not datman format. Ignoring.")
+                continue
 
             if not scan:
                 return False


### PR DESCRIPTION
Some sessions (e.g. SEN01_CMH_SEN053_01_01) have series with malformed series numbers like '11-MR1'. This PR adds error handling to stop the whole script from crashing when these are encountered.