### PR TITLE
[FIX] Adjust pipeline permissions to stop jobs from failing

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,7 +1,7 @@
 name: Assign PR Reviewers
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened]
 

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,7 +1,7 @@
 name: Add a label to a PR
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, reopened, edited, synchronize, ready_for_review]
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ name: Tests
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     branches: [main]
 
 concurrency:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,12 +4,15 @@ name: Tests
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  pull-requests: write
 
 jobs:
   run-tests:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,6 +42,7 @@ jobs:
           pytest-coverage-path: /tmp/pytest-coverage.txt
           junitxml-path: /tmp/pytest.xml
           report-only-changed-files: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create/update coverage badge
         if: github.event_name == 'push'


### PR DESCRIPTION
This should fix the previous job failures without introducing security issues. I can't tell if the run-tests permissions are sufficiently permissive until this PR is merged, since the github token permissions wont update until post-merge, but it should only need pull request write permission.