### PR TITLE
[ENH] un-hardcode dm_blacklist_rm's list of directories to purge from

### DIFF
--- a/assets/config_templates/main_config.yml
+++ b/assets/config_templates/main_config.yml
@@ -207,7 +207,13 @@ IgnoreHeaderFields:              # Dicom Header fields to exclude from gold
 # UsesTechNotes: False           # Indicate whether tech notes are expected
                                  # in each session's resources folder.
                                  # Default: False
+
 # TaskRegex: 'behav|\.edat2'     # A regex used by dm_task_files.py to find
                                  # behavioural files that might exist in the
                                  # study's resources folder. (Optional).
                                  # Default: 'behav|\.edat2'
+
+# BlacklistDel: [nii, mnc, nrrd, resources]   # Indicate which directories to
+                                              # delete blacklisted data from.
+                                              # Default: [nii, mnc, nrrd,
+                                              #           resources]

--- a/bin/dm_blacklist_rm.py
+++ b/bin/dm_blacklist_rm.py
@@ -2,9 +2,6 @@
 """
 Searches the file system for any data on the blacklist and deletes them.
 
-WARNING: This is not a replacement for making sure that pipeline scripts
-respect the blacklist! It will only clean the data folder.
-
 Usage:
     dm_blacklist_rm.py [options] [--path=KEY]... <project>
 
@@ -12,7 +9,7 @@ Arguments:
     <project>           The name of a datman managed project
 
 Options:
-    --path KEY          If provided overrides the 'blacklist_rm' setting
+    --path KEY          If provided overrides the 'BlacklistDel' setting
                         from the config files, which defines the directories
                         to delete blacklisted items from. 'KEY' may be the name
                         of any path defined in the main config file (e.g.
@@ -73,7 +70,7 @@ def get_base_paths(config, user_paths):
         path_keys = user_paths
     else:
         try:
-            path_keys = config.get_key("blacklist_rm")
+            path_keys = config.get_key("BlacklistDel")
         except datman.config.UndefinedSetting:
             # Fall back to the default
             path_keys = ['nii', 'mnc', 'nrrd', 'resources']

--- a/docs/datman_conf.rst
+++ b/docs/datman_conf.rst
@@ -85,6 +85,33 @@ what settings are used for each of the three defined sites in StudyB.
 Glossary
 --------
 
+Blacklist
+*********
+These settings are used by ``dm_blacklist_rm`` and any other scripts that
+read from / remove blacklisted data.
+
+Optional
+^^^^^^^^
+* **BlacklistDel**
+
+  * Description: Defines which directories to delete blacklisted data from.
+    This value is read by ``dm_blacklist_rm``.
+  * Accepted values: A list of path names, where each path name has already
+    been defined in `Paths`_.
+  * Default value: If omitted ``dm_blacklist_rm`` will delete blacklisted
+    scans from ``nii``, ``mnc``, ``nrrd``, and ``resources``, if these
+    directories exist.
+
+Example
+^^^^^^^
+.. code-block:: yaml
+
+   # To delete from the nifti, resources, and task data folders:
+   BlacklistDel: [nii, resources, task]
+
+   # Or limit deletion to the nifti folder:
+   BlacklistDel: [nii]
+
 ExportInfo
 **********
 This setting belongs in the site settings within a study config file. It


### PR DESCRIPTION
This updates dm_blacklist_rm to use a config value (BlacklistRm) or command line arg (--path) to override the default list of paths to purge blacklisted files from. 