### PR TITLE
ENH: Enable XnatType key in ExportInfo

### DIFF
--- a/tests/test_xnat.py
+++ b/tests/test_xnat.py
@@ -24,7 +24,7 @@ class TestGetPortStr(unittest.TestCase):
         self.mock_config.get_key.side_effect = lambda key: {}[key]
 
     def test_raises_KeyError_when_given_port_is_None_and_config_doesnt_define(
-            self):
+        self):
         with pytest.raises(KeyError):
             datman.xnat.get_port_str(self.mock_config, None)
 
@@ -104,7 +104,7 @@ class TestGetServer(unittest.TestCase):
         assert returned_server != config_server
 
     def test_raises_KeyError_when_server_not_given_and_config_setting_missing(
-            self):
+        self):
         with pytest.raises(KeyError):
             datman.xnat.get_server(self.mock_config)
 
@@ -177,8 +177,47 @@ class TestGetAuth(unittest.TestCase):
                 datman.xnat.get_auth()
 
     def test_raises_KeyError_if_username_found_in_env_and_password_not_set(
-            self):
+        self):
         env = {'XNAT_USER': 'someuser'}
         with pytest.raises(KeyError):
             with patch.dict('os.environ', env, clear=True):
                 datman.xnat.get_auth()
+
+
+class TestXnatScan(unittest.TestCase):
+    @patch('datman.xnat.XNATExperiment')
+    def test_xnat_type_is_used_if_configured(self, mock_experiment):
+
+        scan_json = {
+            'children': [],
+            'meta': [],
+            'data_fields': {
+                'series_description': 'SERIES_DESCRIPTION',
+                'type': 'TYPE_INFO'
+            }
+        }
+
+        xnat_scan = datman.xnat.XNATScan(mock_experiment, scan_json)
+
+        tag_map = {'MOCK_TYPE': {'XnatType': 'TYPE_INFO'}}
+        xnat_scan.set_tag(tag_map)
+        assert xnat_scan.type == 'TYPE_INFO'
+        assert set(xnat_scan.tags) == set(['MOCK_TYPE'])
+
+    @patch('datman.xnat.XNATExperiment')
+    def test_series_description_is_used_if_configured(self, mock_experiment):
+
+        scan_json = {
+            'children': [],
+            'meta': [],
+            'data_fields': {
+                'series_description': 'SERIES_DESCRIPTION',
+                'type': 'TYPE_INFO'
+            }
+        }
+
+        xnat_scan = datman.xnat.XNATScan(mock_experiment, scan_json)
+
+        tag_map = {'MOCK_TYPE': {'SeriesDescription': 'SERIES_DESCRIPTION'}}
+        xnat_scan.set_tag(tag_map)
+        assert set(xnat_scan.tags) == set(['MOCK_TYPE'])


### PR DESCRIPTION
This enables users to use the `XnatType` key in lieu of `SeriesDescription` within a study's `ExportInfo`. The result is that tag identification will happen using XNAT's `Type` data field.

The justification behind using this feature is that XNAT's `Type` data-field is editable whereas SeriesDescription is not. As a result XNAT Project owners/maintainers can override the SeriesDescription if the original SeriesDescription doesn't properly allow us to identify an appropriate Tag.

Also this is a my bad moment but I habitually run yapf when saving code and it formatted a bunch of irrelevant lines.... For the actual changes made look at:

1. The chunk at L1565 in xnat.py
2. The chunk at L187 in tests/test_xnat.py

 