### PR TITLE
[FIX] Stop nightly run log issues

### DIFF
--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -311,15 +311,28 @@ class NiiLinkExporter(SessionExporter):
                     name_map)
                 continue
 
-            bids_files = sorted(
-                matches,
-                key=lambda x: int(parse_bids_filename(x).run)
-            )
+            try:
+                bids_files = sorted(
+                    matches,
+                    key=lambda x: int(parse_bids_filename(x).run)
+                )
+            except ParseException:
+                logger.error(
+                    f"Invalid bids file name found for {self.experiment.name}."
+                    f" Skipping datman nifti links for {tag}.")
+                continue
 
-            dm_files = sorted(
-                dm_names[tag],
-                key=lambda x: int(parse_filename(x)[2])
-            )
+            try:
+                dm_files = sorted(
+                    dm_names[tag],
+                    key=lambda x: int(parse_filename(x)[2])
+                )
+            except ParseException:
+                logger.error(
+                    "Invalid datman file name found for "
+                    f"{self.experiment.name}. Skipping datman nifti links for "
+                    f"{tag}")
+                continue
 
             for idx, item in enumerate(dm_files):
                 if idx >= len(bids_files):

--- a/datman/scanid.py
+++ b/datman/scanid.py
@@ -219,15 +219,19 @@ class BIDSFile(object):
         self.run = run
         self.suffix = suffix
 
-        if echo or task:
+        if echo:
             if any([ce, dir, mod]):
+                raise ParseException("Invalid entity found for echo data")
+        if task:
+            if any([ce, mod]):
                 raise ParseException("Invalid entity found for task data")
         if ce or mod:
             if any([task, echo, dir]):
                 raise ParseException("Invalid entity found for anat data")
         if dir:
-            if any([ce, rec, mod, task, echo]):
+            if any([ce, rec, mod, echo]):
                 raise ParseException("Invalid entity found for multiphase fmap")
+
         self.task = task
         self.acq = acq
         self.ce = ce

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -45,7 +45,7 @@ def get_server(config=None, url=None, port=None):
 
     try:
         port_str = get_port_str(config, port)
-    except KeyError:
+    except UndefinedSetting:
         logger.debug(
             f"XnatPort undefined in config. Omitting port number for {url}")
         port_str = ""

--- a/tests/test_datman_scanid.py
+++ b/tests/test_datman_scanid.py
@@ -567,6 +567,15 @@ def test_bids_file_raises_exception_when_wrong_entities_used_for_fmap():
                                    "rec-somefield_run-1_T1w.nii.gz")
 
 
+def test_bids_file_allows_dir_to_be_used_with_task_data():
+    ident = scanid.parse_bids_filename(
+        "/some/folder/sub-CMP1111_ses-01_task-rest_dir-AP_bold")
+    assert ident.subject == 'CMP1111'
+    assert ident.session == '01'
+    assert ident.dir == 'AP'
+    assert ident.suffix == 'bold'
+
+
 def test_optional_entities_dont_get_parsed_as_suffix():
     optional_entities = "sub-CMH0001_ses-01_{}_T1w.nii.gz"
     for entity in ['run', 'acq', 'ce', 'rec', 'echo', 'ce', 'mod', 'task']:


### PR DESCRIPTION
- 5cfb6a0c6f13be72fb0b8baa22c210a4c6360bbe Allow the 'dir' attribute to be set for func bids file names (CLZ uses dir-AP/PA with rest)
- b3fc9c0bfc6591d68ed606c741bd7b52243b575b Stop a filename parsing error from crashing export for an entire session. 
- de5f811efc0e82d7687ecfd158aa73b7e69e30f6 Catch the correct exception when no XnatPort has been provided