### PR TITLE
[FIX] Handle Split FMAP files

### DIFF
--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -323,12 +323,9 @@ class NiiLinkExporter(SessionExporter):
                     continue
                 name_map[dm_name] = item
 
-        # Report scans that are on XNAT but that dont exist in the name map,
-        # because bids export may have failed (or tag configuration may be
-        # incorrect).
         for scan in dm_names:
             if scan not in name_map:
-                logger.error(f"Expected scan {scan} not found in BIDS folder.")
+                logger.info(f"Expected scan {scan} not found in BIDS folder.")
 
         return name_map
 

--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -384,7 +384,8 @@ class NiiLinkExporter(SessionExporter):
         # Catch split series (dcm2bids adds 1000 to the series number of
         # one of the two files)
         split_num = str(int(num) - 1000).zfill(2)
-        if any([split_num == str(item.series) for item in xnat_scans]):
+        if any([split_num == str(item.series).zfill(2)
+                for item in xnat_scans]):
             return split_num
 
         return num

--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -374,9 +374,20 @@ class NiiLinkExporter(SessionExporter):
         num = str(side_car['SeriesNumber'])
         xnat_scans = [item for item in self.experiment.scans
                       if item.description == description]
-        if not xnat_scans or len(xnat_scans) > 1:
+
+        if not xnat_scans:
             return num
-        return xnat_scans[0].series
+
+        if len(xnat_scans) == 1:
+            return xnat_scans[0].series
+
+        # Catch split series (dcm2bids adds 1000 to the series number of
+        # one of the two files)
+        split_num = str(int(num) - 1000).zfill(2)
+        if any([split_num == str(item.series) for item in xnat_scans]):
+            return split_num
+
+        return num
 
     def _find_matching_files(self, bids_names, bids_conf):
         """Search a list of bids files to find series that match a datman tag.

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -1582,8 +1582,7 @@ class XNATScan(XNATObject):
             if re.search(regex, search_target, re.IGNORECASE):
                 matches[tag] = pattern
 
-        if len(matches) == 1 or (len(matches) == 2 and (
-                self.multiecho or is_split_series(matches))):
+        if len(matches) == 1 or (len(matches) == 2 and self.multiecho):
             self.tags = list(matches.keys())
             return matches
         return self._set_fmap_tag(tag_map, matches)
@@ -1619,8 +1618,7 @@ class XNATScan(XNATObject):
                     self.echo_dict[echo_num] = name
             names.append(name)
 
-        if len(self.tags) > 1 and not (
-                self.multiecho or is_split_series(tag_settings)):
+        if len(self.tags) > 1 and not self.multiecho:
             logger.error(f"Multiple export patterns match for {base_name}, "
                          f"descr: {self.description}, tags: {self.tags}")
             names = []
@@ -1757,17 +1755,3 @@ class XNATScan(XNATObject):
 
     def __repr__(self):
         return self.__str__()
-
-
-def is_split_series(matched_tags):
-    """Check if an XNAT series is meant to be split into multiple niftis.
-
-    Args:
-        matched_tags (:obj:`dict`): A dictionary of tags that match a single
-            XNAT series' description. Each tag should be mapped to its
-            configuration values.
-
-    Returns:
-        bool: True if all matched tags contain the 'SplitSeries' option.
-    """
-    return all(['SplitSeries' in config for config in matched_tags.values()])

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -1582,7 +1582,8 @@ class XNATScan(XNATObject):
             if re.search(regex, search_target, re.IGNORECASE):
                 matches[tag] = pattern
 
-        if len(matches) == 1 or (len(matches) == 2 and self.multiecho):
+        if len(matches) == 1 or (len(matches) == 2 and (
+                self.multiecho or is_split_series(matches))):
             self.tags = list(matches.keys())
             return matches
         return self._set_fmap_tag(tag_map, matches)
@@ -1618,7 +1619,8 @@ class XNATScan(XNATObject):
                     self.echo_dict[echo_num] = name
             names.append(name)
 
-        if len(self.tags) > 1 and not self.multiecho:
+        if len(self.tags) > 1 and not (
+                self.multiecho or is_split_series(tag_settings)):
             logger.error(f"Multiple export patterns match for {base_name}, "
                          f"descr: {self.description}, tags: {self.tags}")
             names = []
@@ -1755,3 +1757,17 @@ class XNATScan(XNATObject):
 
     def __repr__(self):
         return self.__str__()
+
+
+def is_split_series(matched_tags):
+    """Check if an XNAT series is meant to be split into multiple niftis.
+
+    Args:
+        matched_tags (:obj:`dict`): A dictionary of tags that match a single
+            XNAT series' description. Each tag should be mapped to its
+            configuration values.
+
+    Returns:
+        bool: True if all matched tags contain the 'SplitSeries' option.
+    """
+    return all(['SplitSeries' in config for config in matched_tags.values()])

--- a/tests/test_datman_exporters.py
+++ b/tests/test_datman_exporters.py
@@ -1,37 +1,84 @@
+import os
+
 import pytest
 from mock import Mock, patch
 
 import datman.exporters as exporters
+from datman.config import TagInfo
 
 
 class TestNiiLinkExporter:
 
-    # Needs:
-    #   - list of expected tags with 'Bids' config
-    #   - experiment.name in case of error
-    #   - dict of {TAG: [names]} for datman matches
-    #   - list of full path bids file names (all rooted in a folder, no ext)
+    def test_match_dm_to_bids_matches_configured_scans_correctly(
+            self, config, session, experiment):
 
-    def test_match_dm_to_bids_correctly_matches_t1_anat(self, config):
+        exporter = exporters.NiiLinkExporter(config, session, experiment)
 
-        assert False
+        dm_names = {
+            'T1': [f'{experiment.name}_T1_03_T1w'],
+            'DTI-ABCD': [f'{experiment.name}_DTI-ABCD_05_Ax-DTI-60plus5']
+        }
 
-    # def test_match_dm_to_bids_works_when_tag_count_greater_than_one(self):
-    #     assert False
-    #
-    # def test_match_dm_to_bids_matches_split_series_correctly(self):
-    #     assert False
-    #
-    # def test_match_dm_to_bids_matches_files_when_dm_name_not_assigned(self):
-    #     assert False
-    #
-    # def test_match_dm_to_bids_doesnt_match_unneeded_files(self):
-    #     # Must match CBF with unknown description, but not accidentally
-    #     # grab other random series
-    #     assert False
+        bids_names = [
+            f'{session.bids_path}/dwi/sub-CMH0000_ses-01_dwi',
+            f'{session.bids_path}/anat/sub-CMH0000_ses-01_T1w'
+        ]
 
-    # def test_sidecars_and_other_files_get_links_if_nii_does(self):
-    #     assert False
+        matches = exporter.match_dm_to_bids(dm_names, bids_names)
+
+        assert len(matches) == 1
+        assert dm_names['T1'][0] in matches
+        assert matches[dm_names['T1'][0]] == bids_names[1]
+
+    def test_match_dm_to_bids_works_when_tag_count_greater_than_one(
+            self, config, session, experiment):
+
+        exporter = exporters.NiiLinkExporter(config, session, experiment)
+
+        dm_names = {
+            'NBK': [
+                f'{experiment.name}_NBK_07_Nback-fMRI',
+                f'{experiment.name}_NBK_12_Nback-fMRI'
+            ]
+        }
+
+        bids_names = [
+            f'{session.bids_path}/dwi/sub-CMH0000_ses-01_dwi',
+            (f'{session.bids_path}/func/sub-CMH0000_ses-01_task-nback_'
+                'run-02_bold'),
+            f'{session.bids_path}/anat/sub-CMH0000_ses-01_T1w',
+            (f'{session.bids_path}/func/sub-CMH0000_ses-01_task-nback_'
+                'run-01_bold')
+        ]
+
+        matches = exporter.match_dm_to_bids(dm_names, bids_names)
+
+        assert len(matches) == 2
+        assert dm_names['NBK'][0] in matches
+        assert matches[dm_names['NBK'][0]] == bids_names[3]
+        assert dm_names['NBK'][1] in matches
+        assert matches[dm_names['NBK'][1]] == bids_names[1]
+
+    def test_match_dm_to_bids_matches_files_when_dm_name_not_assigned(
+            self, config, session, experiment):
+
+        exporter = exporters.NiiLinkExporter(config, session, experiment)
+
+        dm_names = {}
+        bids_names = [
+            f'{session.bids_path}/dwi/sub-CMH0000_ses-01_dwi',
+            f'{session.bids_path}/perf/sub-CMH0000_ses-01_cbf',
+            f'{session.bids_path}/perf/sub-CMH0000_ses-01_m0scan'
+        ]
+
+        matches = exporter.match_dm_to_bids(dm_names, bids_names)
+
+        expected_name = f'{experiment.name}_CBF_08_cbf'
+        assert len(matches) == 1
+        assert expected_name in matches
+        assert matches[expected_name] == bids_names[0]
+
+
     @pytest.fixture
     def config(self):
         """Create a mock datman config object, with tags defined.
@@ -39,19 +86,42 @@ class TestNiiLinkExporter:
         test_tags = {
             'T1': {
                 'Bids': {'class': 'anat', 'modality_label': 'T1w'},
-                'Pattern': 'T1',
                 'Count': 1
             },
+            'NBK': {
+                'Bids': {
+                    'class': 'func',
+                    'contrast_label': 'bold',
+                    'task': 'nback'
+                },
+                'Count': 2
+            },
+            'CBF': {
+                'Bids': {'class': 'perf', 'modality_label': 'cbf'},
+                'Count': 1
+            }
         }
 
+        def get_tags(site=None):
+            return TagInfo(test_tags)
+
         config = Mock()
-        config.get_tags = lambda x: test_tags
+        config.get_tags = get_tags
+
+        return config
+
+    @pytest.fixture
+    def session(self):
+        session = Mock()
+        session.nii_path = "/some/study/data/nii/STUDY01_CMH_0000_01"
+        session.bids_path = "/some/study/data/bids/sub-CMH0000/ses-01"
+        return session
 
     @pytest.fixture
     def experiment(self):
         exp = Mock()
         exp.name = 'STUDY01_CMH_0000_01_01'
-
+        exp.scans = []
         return exp
 
 

--- a/tests/test_datman_exporters.py
+++ b/tests/test_datman_exporters.py
@@ -1,0 +1,61 @@
+import pytest
+from mock import Mock, patch
+
+import datman.exporters as exporters
+
+
+class TestNiiLinkExporter:
+
+    # Needs:
+    #   - list of expected tags with 'Bids' config
+    #   - experiment.name in case of error
+    #   - dict of {TAG: [names]} for datman matches
+    #   - list of full path bids file names (all rooted in a folder, no ext)
+
+    def test_match_dm_to_bids_correctly_matches_t1_anat(self, config):
+
+        assert False
+
+    # def test_match_dm_to_bids_works_when_tag_count_greater_than_one(self):
+    #     assert False
+    #
+    # def test_match_dm_to_bids_matches_split_series_correctly(self):
+    #     assert False
+    #
+    # def test_match_dm_to_bids_matches_files_when_dm_name_not_assigned(self):
+    #     assert False
+    #
+    # def test_match_dm_to_bids_doesnt_match_unneeded_files(self):
+    #     # Must match CBF with unknown description, but not accidentally
+    #     # grab other random series
+    #     assert False
+
+    # def test_sidecars_and_other_files_get_links_if_nii_does(self):
+    #     assert False
+    @pytest.fixture
+    def config(self):
+        """Create a mock datman config object, with tags defined.
+        """
+        test_tags = {
+            'T1': {
+                'Bids': {'class': 'anat', 'modality_label': 'T1w'},
+                'Pattern': 'T1',
+                'Count': 1
+            },
+        }
+
+        config = Mock()
+        config.get_tags = lambda x: test_tags
+
+    @pytest.fixture
+    def experiment(self):
+        exp = Mock()
+        exp.name = 'STUDY01_CMH_0000_01_01'
+
+        return exp
+
+
+# class NiiExporter:
+#
+#     def test_split_series_doesnt_export_same_file_with_two_names(self):
+#         assert False


### PR DESCRIPTION
This updates the NiiLinkExporter code to better handle split files and files that can't be assigned a correct file name with the older NiiExporter. It also adds some tests to catch some of the things that were missed when links were made to the bids folder.