### PR TITLE
[FIX] Fix REDCAP ID issue + linked scans missed by datman.exporters.DBExporter

### DIFF
--- a/bin/dm_redcap_scan_completed.py
+++ b/bin/dm_redcap_scan_completed.py
@@ -78,7 +78,8 @@ def get_version(api_url, token):
 
 def add_session_redcap(record, record_key):
     record_id = record[record_key]
-    subject_id = record[get_setting('RedcapSubj', default='par_id')].upper()
+    subject_id = record[get_setting('RedcapSubj', default='par_id')]
+    subject_id = subject_id.strip().upper()
     if not datman.scanid.is_scanid(subject_id):
         subject_id = subject_id + '_01'
         try:


### PR DESCRIPTION
- Stop redcap subid fields from raising exceptions when the user left whitespace after the ID (b71bc0defb7e98eadee62eaef9acc61686abbbcf)
- Stop linked scans from being left out of the database when datman.xnat.XNATExperiment can't name them correctly (e.g. CBF files for TAY) (ce66ddecb07229585423a65b4b211033bfd36811)