### PR TITLE
[FIX] update xnat_extract NiiLink to stop repeats from being linked under multiple session numbers

### DIFF
--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -328,16 +328,17 @@ class NiiLinkExporter(SessionExporter):
         return bids_niftis
 
     def belongs_to_session(self, nifti):
-        """Check if the nifti belongs to this session (or to a repeat).
+        """Check if a nifti belongs to this repeat or another for this session.
 
         Args:
-            nifti (str): The full path to a nifti file.
+            nifti (str): A nifti file name from the bids folder.
 
         Returns:
             bool: True if the nifti file belongs to this particular
-                repeat/session. False if it belongs to another repeat/session.
+                repeat. False if it belongs to another repeat.
         """
-        json_path = nifti.replace(get_extension(nifti), ".json")
+        nii_path = os.path.join(self.bids_path, nifti)
+        json_path = nifti.replace(get_extension(nii_path), ".json")
         try:
             side_car = read_json(json_path)
         except FileNotFoundError:

--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -179,6 +179,7 @@ class BidsExporter(SessionExporter):
         self.exp_label = experiment.name
         self.bids_sub = session._ident.get_bids_name()
         self.bids_ses = session._ident.timepoint
+        self.repeat = session._ident.session
         self.bids_folder = session.bids_root
         self.output_dir = session.bids_path
         self.keep_dcm = bids_opts.keep_dcm if bids_opts else False
@@ -192,15 +193,22 @@ class BidsExporter(SessionExporter):
         return os.path.join(download_dir, self.exp_label, "scans")
 
     def outputs_exist(self):
-        # Can't get more granular than this at the moment
-        if os.path.exists(self.output_dir):
-            if self.clobber:
-                logger.info(
-                    f"{self.output_dir} will be overwritten due to "
-                    "clobber option.")
-                return False
-            logger.info("(Use --clobber to overwrite)")
+        if self.clobber:
+            logger.info(
+                f"{self.output_dir} will be overwritten due to clobber option."
+            )
+            return False
+
+        sidecars = self.get_sidecars()
+        repeat_nums = [sidecars[path].get("repeat") for path in sidecars]
+
+        if any([repeat == self.repeat for repeat in repeat_nums]):
             return True
+
+        if self.repeat == "01" and sidecars:
+            # Catch instances where adding repeat to sidecars failed.
+            return True
+
         return False
 
     def needs_raw_data(self):
@@ -218,6 +226,10 @@ class BidsExporter(SessionExporter):
         if self.dry_run:
             logger.info(f"Dry run: Skipping bids export to {self.output_dir}")
             return
+
+        if int(self.repeat) > 1:
+            # Must force dcm2niix export if it's a repeat.
+            self.force_dcm2niix = True
 
         self.make_output_dir()
 
@@ -239,6 +251,40 @@ class BidsExporter(SessionExporter):
                 f"Dcm2Bids failed to run for {self.output_dir}. "
                 f"{type(exc)}: {exc}"
             )
+
+        try:
+            self.add_repeat_num()
+        except (PermissionError, json.JSONDecodeError):
+            logger.error(
+                "Failed to add repeat numbers to sidecars in "
+                f"{self.output_dir}. If a repeat scan is added, scans may "
+                "incorrectly be tagged as belonging to the later repeat."
+            )
+
+    def add_repeat_num(self):
+        orig_contents = self.get_sidecars()
+
+        for path in orig_contents:
+            if orig_contents[path].get("repeat"):
+                continue
+
+            logger.info(f"Adding repeat num {self.repeat} to sidecar {path}")
+            orig_contents[path]["repeat"] = self.repeat
+            self.write_json(path, orig_contents[path])
+
+    def get_sidecars(self):
+        sidecars = glob.glob(os.path.join(self.output_dir, "*", "*.json"))
+        contents = {path: self.read_json(path) for path in sidecars}
+        return contents
+
+    def read_json(self, path):
+        with open(path) as fh:
+            contents = json.load(fh)
+        return contents
+
+    def write_json(self, path, contents):
+        with open(path, "w") as fh:
+            json.dump(contents, fh)
 
 
 class NiiLinkExporter(SessionExporter):

--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -200,7 +200,7 @@ class BidsExporter(SessionExporter):
             return False
 
         sidecars = self.get_sidecars()
-        repeat_nums = [sidecars[path].get("repeat") for path in sidecars]
+        repeat_nums = [sidecars[path].get("Repeat") for path in sidecars]
 
         if any([repeat == self.repeat for repeat in repeat_nums]):
             return True
@@ -265,15 +265,15 @@ class BidsExporter(SessionExporter):
         orig_contents = self.get_sidecars()
 
         for path in orig_contents:
-            if orig_contents[path].get("repeat"):
+            if orig_contents[path].get("Repeat"):
                 continue
 
             logger.info(f"Adding repeat num {self.repeat} to sidecar {path}")
-            orig_contents[path]["repeat"] = self.repeat
+            orig_contents[path]["Repeat"] = self.repeat
             self.write_json(path, orig_contents[path])
 
     def get_sidecars(self):
-        sidecars = glob.glob(os.path.join(self.output_dir, "*", "*.json"))
+        sidecars = glob(os.path.join(self.output_dir, "*", "*.json"))
         contents = {path: self.read_json(path) for path in sidecars}
         return contents
 
@@ -284,7 +284,7 @@ class BidsExporter(SessionExporter):
 
     def write_json(self, path, contents):
         with open(path, "w") as fh:
-            json.dump(contents, fh)
+            json.dump(contents, fh, indent=4)
 
 
 class NiiLinkExporter(SessionExporter):

--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -321,26 +321,25 @@ class NiiLinkExporter(SessionExporter):
         for path, _, files in os.walk(self.bids_path):
             niftis = filter_niftis(files)
             for item in niftis:
-                if not self.belongs_to_session(item):
-                    continue
                 basename = item.replace(get_extension(item), "")
-                bids_niftis.append(os.path.join(path, basename))
+                nii_path = os.path.join(path, basename)
+                if self.belongs_to_session(nii_path):
+                    bids_niftis.append(nii_path)
         return bids_niftis
 
-    def belongs_to_session(self, nifti):
+    def belongs_to_session(self, nifti_path):
         """Check if a nifti belongs to this repeat or another for this session.
 
         Args:
-            nifti (str): A nifti file name from the bids folder.
+            nifti_path (str): A nifti file name from the bids folder (minus
+                extension).
 
         Returns:
             bool: True if the nifti file belongs to this particular
                 repeat. False if it belongs to another repeat.
         """
-        nii_path = os.path.join(self.bids_path, nifti)
-        json_path = nifti.replace(get_extension(nii_path), ".json")
         try:
-            side_car = read_json(json_path)
+            side_car = read_json(nifti_path + ".json")
         except FileNotFoundError:
             # Assume it belongs if a side car cant be read.
             return True

--- a/datman/utils.py
+++ b/datman/utils.py
@@ -3,6 +3,7 @@ A collection of utilities for generally munging imaging data.
 """
 import contextlib
 import io
+import json
 import logging
 import os
 import random
@@ -1361,3 +1362,14 @@ def find_tech_notes(folder):
                 return pdf
 
     return pdf_list[0]
+
+
+def read_json(path):
+    with open(path) as fh:
+        contents = json.load(fh)
+    return contents
+
+
+def write_json(path, contents):
+    with open(path, "w") as fh:
+        json.dump(contents, fh, indent=4)


### PR DESCRIPTION
This depends on https://github.com/TIGRLab/datman/pull/350. Previously, because there was no way to tell which repeat a particular scan in the bids folder belonged to, scans in the bids folder were being mislinked as belonging to all repeat/sessions that existed for a timepoint. This fixes this by using the side car contents, which https://github.com/TIGRLab/datman/pull/350 updates to contain the correct repeat number.