### PR TITLE
[FIX] Ensure tech notes are pushed if they arrive after scan data

### DIFF
--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -663,6 +663,9 @@ class DBExporter(SessionExporter):
         if not session:
             return False
 
+        if not session.tech_notes and session.expects_notes():
+            return False
+
         for name in self.names:
             try:
                 scan = datman.dashboard.get_scan(name)


### PR DESCRIPTION
PREDICTS uncovered a bug with tech notes not being detected / added to the dashboard if they're downloaded after the rest of the scan data has already arrived. Added a check to 'DBExporter.outputs_exist()' to ensure the database gets updated.