### PR TITLE
[FIX] Update API URL retrieval, and documentation for the config val

### DIFF
--- a/assets/config_templates/main_config.yml
+++ b/assets/config_templates/main_config.yml
@@ -148,8 +148,9 @@ ExportSettings:
 # UsesRedcap: False              # Whether or not to expect a REDCap scan
                                  # completed survey for each MR session.
                                  # Default: False
-# RedcapApi: <api url>           # The API URL for the REDCap server.
 # RedcapUrl: <redcap url>        # The URL for the REDCap server.
+# RedcapApiUrl: <api url>        # The API URL for the REDCap server.
+                                 # Default: RedcapUrl
 # RedcapToken: <filename>        # The name of the file in each study's
                                  # metadata folder that contains the REDCap
                                  # token to use.

--- a/bin/dm_redcap_scan_completed.py
+++ b/bin/dm_redcap_scan_completed.py
@@ -210,8 +210,8 @@ def main():
     dir_meta = cfg.get_path('meta')
 
     # configure redcap variables
-    api_url = cfg.get_key('RedcapUrl')
-    redcap_url = api_url.replace('/api/', '/')
+    redcap_url = cfg.get_key('RedcapUrl')
+    api_url = get_setting('RedcapApiUrl', default=redcap_url)
 
     token_path = os.path.join(dir_meta, cfg.get_key('RedcapToken'))
     token = read_token(token_path)

--- a/docs/datman_conf.rst
+++ b/docs/datman_conf.rst
@@ -591,14 +591,14 @@ settings are used by scripts like ``dm_redcap_scan_complete.py``,
 
 Required
 ^^^^^^^^
-* **RedcapApi**:
 
-  * Description: The URL for the REDCap API endpoint.
-  * Used by: dm_link_shared_ids.py
 * **RedcapUrl**:
 
-  * Description: The URL for the REDCap server to pull information from.
-  * Used by: dm_redcap_scan_complete.py
+  * Description: The URL of the REDCap server to query for surveys. If the
+    'Data Entry Trigger' feature is being used, this must match the URL
+    contained in the requests that will be sent (this should just be the
+    plain old home page URL).
+  * Used by: dm_redcap_scan_complete.py and the QC dashboard if it's installed.
 * **RedcapProjectId**:
 
   * Description: The project ID to use when retrieving records.
@@ -619,6 +619,12 @@ Required
 
 Optional
 ^^^^^^^^
+* **RedcapApiUrl**:
+
+  * Description: The URL for the REDCap API. Only needed if this URL differs
+    from RedcapUrl.
+  * Default: 'RedcapUrl'
+  * Used by: dm_link_shared_ids.py
 * **RedcapComments**:
 
   * Description: The name of the survey field that holds comments from the
@@ -642,7 +648,8 @@ Optional
   * Default: '2'
 * **RedcapSubj**:
 
-  * Description: The name of the survey field that holds the session ID
+  * Description: The name of the survey field that holds the correctly
+    formatted session ID.
   * Default: 'par_id'
 * **RedcapToken**:
 
@@ -664,8 +671,8 @@ Example
 .. code-block:: yaml
 
   UsesRedcap: True    # if unset, is treated as False
-  RedcapApi: myredcapserver.com/api # These two can refer to different servers
   RedcapUrl: myredcapserver.com
+  RedcapApiUrl: myredcapserver.com/api # These URLs can refer to different servers
   RedcapToken: 'mytoken.txt'  # Should exist in $STUDY/metadata,
                               # if unset, REDCAP_TOKEN env var is read
   RedcapProjectId: '1111'


### PR DESCRIPTION
Previously I tried to remove the RedcapApi setting because it was super redundant and created confusion, but recently this has started causing trouble with predicts. SO. I've put it back in under the name 'RedcapApiUrl' and updated our documentation in a way that will hopefully be clear, while also allowing plain-old RedcapUrl to be used when there are no differences in the URL.