### PR TITLE
[FIX] Stop series download from failing silently

### DIFF
--- a/bin/dm_xnat_extract.py
+++ b/bin/dm_xnat_extract.py
@@ -68,10 +68,11 @@ class BidsOptions:
 
     def __init__(self, config, keep_dcm=False, bids_out=None,
                  force_dcm2niix=False, clobber=False, dcm2bids_config=None,
-                 log_level="INFO"):
+                 log_level="INFO", refresh=False):
         self.keep_dcm = keep_dcm
         self.force_dcm2niix = force_dcm2niix
         self.clobber = clobber
+        self.refresh = refresh
         self.bids_out = bids_out
         self.log_level = log_level
         self.dcm2bids_config = self.get_bids_config(
@@ -128,7 +129,8 @@ def main():
             force_dcm2niix=args.force_dcm2niix,
             clobber=args.clobber,
             dcm2bids_config=args.dcm_config,
-            bids_out=args.bids_out
+            bids_out=args.bids_out,
+            refresh=args.refresh
         )
     else:
         bids_opts = None
@@ -256,6 +258,12 @@ def read_args():
         "--clobber", action="store_true", default=False,
         help="Clobber previous bids data"
     )
+    g_dcm2bids.add_argument(
+        "--refresh", action="store_true", default=False,
+        help="Refresh previously exported bids data by re-running against an "
+             "existing tmp folder in the bids output directory. Useful if the "
+             "contents of the configuration file changes."
+    )
 
     g_perfm = parser.add_argument_group("Options for logging and debugging")
     g_perfm.add_argument(
@@ -282,7 +290,7 @@ def read_args():
     args = parser.parse_args()
 
     bids_opts = [args.keep_dcm, args.dcm_config, args.bids_out,
-                 args.force_dcm2niix, args.clobber]
+                 args.force_dcm2niix, args.clobber, args.refresh]
     if not args.use_dcm2bids and any(bids_opts):
         parser.error("dcm2bids configuration requires --use-dcm2bids")
 

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -999,7 +999,7 @@ class xnat(object):
                            "?wrk:workflowData/status=Complete")
             self._make_xnat_put(dismiss_url)
 
-    def _get_xnat_stream(self, url, filename, retries=3, timeout=120):
+    def _get_xnat_stream(self, url, filename, retries=3, timeout=300):
         logger.debug(f"Getting {url} from XNAT")
         try:
             response = self.session.get(url, stream=True, timeout=timeout)
@@ -1013,10 +1013,10 @@ class xnat(object):
                 raise e
 
         if response.status_code == 401:
-            # possibly the session has timed out
             logger.info("Session may have expired, resetting")
             self.open_session()
-            response = self.session.get(url, stream=True, timeout=timeout)
+            return self._get_xnat_stream(
+                    url, filename, retries=retries, timeout=timeout)
 
         if response.status_code == 404:
             logger.info(


### PR DESCRIPTION
Recently we've noticed that xnat downloads of some dicom series were failing sporadically. Then, dcm2bids was exporting from the incompletely downloaded data. Our code was then seeing the bids folder for the session and skipping it for future re-extraction attempts causing the data to be missing from the archive until an RA notices and points it out to us.

This fixes this situation by:
   1. Increasing the starting timeout duration for downloads
   2. Fixing a bug that was making our code susceptible to 404 errors after our xnat session timed out
   3. Adding error files to the nii folder when NiiLinkExporter is used, so the missing scans can be reported in the dashboard
   4. Adding a mode to dm_xnat_extract to re-extract using the tmp folder for situations when the bids config changes (unrelated to the above error, but sneaking this enhancement in here since I needed it incidentally while working on CDIA's missing files).