### PR TITLE
[ENH] Allow datman to handle linked XNAT sessions

### DIFF
--- a/bin/dm_redcap_scan_completed.py
+++ b/bin/dm_redcap_scan_completed.py
@@ -94,6 +94,8 @@ def add_session_redcap(record, record_key):
         return
 
     session_date = record[get_setting('RedcapDate', default='date')]
+    # Strip off optional 'hours' field'
+    session_date = session_date.split(" ")[0]
 
     try:
         session = dashboard.get_session(ident, date=session_date, create=True)

--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -875,7 +875,7 @@ class DBExporter(SessionExporter):
         matches = [
             source_scan for source_scan in source_session.scans
             if (source_scan.series == scan.series and
-                source_scan.tag == source_scan.tag)
+                source_scan.tag == scan.tag)
         ]
         if not matches or len(matches) > 1:
             logger.error(

--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -1136,8 +1136,11 @@ class SharedExporter(SessionExporter):
                     self.source_session.id_plus_session
                 )
                 for match in glob(os.path.join(source_dir, f"{source_name}*")):
-                    ext = get_extension(match)
-                    name_map[match] = os.path.join(dest_dir, name + ext)
+                    fname = os.path.basename(match).replace(
+                        self.source_session.id_plus_session,
+                        self.session.id_plus_session
+                    )
+                    name_map[match] = os.path.join(dest_dir, fname)
 
         return name_map
 

--- a/datman/exporters.py
+++ b/datman/exporters.py
@@ -662,11 +662,11 @@ class DBExporter(SessionExporter):
         self.study_resource_path = study_resource_dir
         self.resources_path = resources_dir
         self.date = experiment.date
-        self.names = self.get_scan_names(session, experiment)
         super().__init__(config, session, experiment, **kwargs)
 
-    def get_scan_names(self, session, experiment):
-        """Gets list of datman-style scan names for a session.
+    @property
+    def names(self):
+        """Gets list of valid datman-style scan names for a session.
 
         Returns:
             :obj:`dict`: A dictionary of datman style scan names mapped to
@@ -675,17 +675,17 @@ class DBExporter(SessionExporter):
         """
         names = {}
         # use experiment.scans, so dashboard can report scans that didnt export
-        for scan in experiment.scans:
+        for scan in self.experiment.scans:
             for name in scan.names:
-                names[name] = self.get_bids_name(name, session)
+                names[name] = self.get_bids_name(name, self.session)
 
         # Check the actual folder contents as well, in case symlinked scans
         # exist that werent named on XNAT
-        for nii in session.niftis:
+        for nii in self.session.niftis:
             fname = nii.file_name.replace(nii.ext, "")
             if fname in names:
                 continue
-            names[fname] = self.get_bids_name(fname, session)
+            names[fname] = self.get_bids_name(fname, self.session)
 
         return names
 

--- a/datman/scan.py
+++ b/datman/scan.py
@@ -131,11 +131,13 @@ class Scan(DatmanNamed):
         self.resource_path = self.__get_path(
             "resources", config, session=True)
 
-        self.niftis = self.__get_series(self.nii_path, [".nii", ".nii.gz"])
-
         self.__nii_dict = self.__make_dict(self.niftis)
 
         self.nii_tags = list(self.__nii_dict.keys())
+
+    @property
+    def niftis(self):
+        return self.__get_series(self.nii_path, ['nii', '.nii.gz'])
 
     def _get_ident(self, subid):
         subject_id = self.__check_session(subid)

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -1507,6 +1507,22 @@ class XNATExperiment(XNATObject):
                     f"in session {str(ident)}. Reason {type(e).__name__}: "
                     f"{e}")
 
+    def is_shared(self):
+        """Detect if the experiment is shared from another XNAT Project.
+
+        Shared sessions have identical metadata to their source sessions,
+        the only way to tell a link apart from source data is to look for a
+        'sharing/share' entry and check its xnat label.
+        """
+        if self.subject in self.name:
+            return False
+
+        share_entry = self._get_contents('sharing/share')
+        if not share_entry:
+            return False
+
+        return self.subject in share_entry[0][0]['data_fields']['label']
+
     def __str__(self):
         return f"<XNATExperiment {self.name}>"
 


### PR DESCRIPTION
- Add a function to detect a shared XNAT experiment (46468149daffab9ec2b778466b86fd8a35815410)
- Add a `datman.exporters.SharedExporter` class that finds and symlinks relevant files (i.e. those with the correctly configured tags) from the XNAT source session (b642855c3bdb844403baab8bb4a619eeb2a66c2a, 9584af84addc5e2d50ed5c1ee1f30417a82e4469, 85b3d015d881e493b5b5d73a60b228877a96895e, b61671fb3e61ee27c47de118da455f3f8e446bf6, d45703cc6e38b048bb031320494758d447cfead0)
- Update `datman.exporters.DBExporter` to mark shared scans with the correct source scan ID (7f8f8a7da36cd7eaf8f7392addde3858d44caa9f)
- Fix `datman.exporters.DBExporter` bugs related to some scans missing on the first run of `datman/bin/dm_xnat_extract.py` when those scans first export only to bids (instead of the legacy nii folder) (09bb73f625be800d11b902e3468b7684784420fd)
- Fix a `datman.scan.Scan` bug causing some scans to be missed because the .niftis property did not update after object creation (b4620a118683bbe3ad2485cd9616ef48c8851001)
- Fix a date parsing related exception that prevented DEEPPI redcap records from being added to the database (525dfdbbc0992331559e3668d08eba3a40aee249)