### PR TITLE
[ENH] Add better error messages + filter out noisy redcap messages

### DIFF
--- a/bin/dm_link.py
+++ b/bin/dm_link.py
@@ -221,8 +221,11 @@ def link_archive(archive_path, dicom_path, scanid_field, config):
     target = os.path.join(dicom_path, scanid)
     target = target + datman.utils.get_extension(archive_path)
     if os.path.exists(target):
-        logger.error("Target: {} already exists for archive: {}"
-                     .format(target, archive_path))
+        logger.error(
+            f"Target path {target} for archive {archive_path} is already in "
+            f"use by another zip file ({os.path.realpath(target)}). "
+            "Please investigate."
+        )
         return
 
     relpath = os.path.relpath(archive_path, dicom_path)

--- a/bin/dm_redcap_scan_completed.py
+++ b/bin/dm_redcap_scan_completed.py
@@ -6,15 +6,19 @@ Usage:
     dm_redcap_scan_completed.py [options] <study>
 
 Arguments:
-    <study>             Name of the study to process
+    <study>                 Name of the study to process
 
 Options:
-    -q --quiet          Less logging
-    -v --verbose        Verbose logging
-    -d --debug          Debug logging
+    --ignore <regex>        An optional regex used to ignore records with
+                            a matching subject ID field. Regex must follow the
+                            python 're' library rules.
+    -q --quiet              Less logging
+    -v --verbose            Verbose logging
+    -d --debug              Debug logging
 """
 
 import os
+import re
 import sys
 import requests
 import logging
@@ -179,6 +183,7 @@ def main():
 
     arguments = docopt(__doc__)
     study = arguments['<study>']
+    ignore_re = arguments['--ignore']
     quiet = arguments['--quiet']
     verbose = arguments['--verbose']
     debug = arguments['--debug']
@@ -239,6 +244,11 @@ def main():
     for item in response_json:
         # only grab records where instrument has been marked complete
         if not (item[date_field] and item[status_field] in status_val):
+            continue
+        # Filter out records when the subject ID matches an optional regex
+        if ignore_re and re.match(ignore_re,
+                                  item[get_setting('RedcapSubj',
+                                                   default='par_id')]):
             continue
         project_records.append(item)
 

--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -1706,6 +1706,14 @@ class XNATScan(XNATObject):
                          f" series {self.series}. Reason - {e}")
             return False
 
+        if os.path.getsize(dicom_zip) == 0:
+            logger.error(
+                f"Server returned an empty file for series {self.series} in "
+                f"session {self.experiment}. This may be a server error."
+            )
+            os.remove(dicom_zip)
+            return False
+
         logger.info(f"Unpacking archive {dicom_zip}")
 
         try:


### PR DESCRIPTION
This PR:

- Adds a clearer error message when the XNAT server returns an empty file [`datman/xnat.py`, 01ca591de2786cd9a294161523968d77e249d253]
- Adds a message that's more useful for debugging when a zip file's intended ID is already in use by another file [`bin/dm_link.py`, 5a112678b2eb82bde6434b69b2a91fa53bca4bbf]
- Prevents task files from being named with unparseable characters (which can break scripts that use the task files) [`bin/dm_task_files.py`, 01bd074dcef9dfa51ff95b60c6c8aea140f516eb]
- Allows redcap record IDs matching a regex to be ignored, helping to limit noise when unneeded records may be in the same project [`bin/dm_redcap_scan_completed.py`, 230d2495afd0431ca85520f4fced008b5851d2d6]