### PR TITLE
[ENH] Add --refresh flag to dm_qc_report

### DIFF
--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -22,7 +22,7 @@ Options:
 
 Requires:
     FSL/5.0.10
-    MATLAB/R2014a - qa-dti phantom pipeline
+    matlab/R2014a - qa-dti phantom pipeline
     AFNI/2014.12.16 - abcd_fmri phantom pipeline
 """
 

--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -411,6 +411,10 @@ def add_scan_length(nii_path, scan):
 
 
 def remove_outputs(metric):
+    try:
+        os.remove(metric.manifest_path)
+    except FileNotFoundError:
+        pass
     for command in metric.outputs:
         for item in metric.outputs[command]:
             try:

--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -157,7 +157,7 @@ def submit_subjects(config):
         logger.info(f"Submitting QC job for {subject}.")
         datman.utils.submit_job(
             command, job_name, "/tmp", system=config.system,
-            argslist="--mem=3G"
+            argslist="--mem=5G"
         )
 
 

--- a/bin/dm_qc_report.py
+++ b/bin/dm_qc_report.py
@@ -411,11 +411,12 @@ def add_scan_length(nii_path, scan):
 
 
 def remove_outputs(metric):
-    for item in metric.outputs:
-        try:
-            os.remove(item)
-        except FileNotFoundError:
-            pass
+    for command in metric.outputs:
+        for item in metric.outputs[command]:
+            try:
+                os.remove(item)
+            except FileNotFoundError:
+                pass
 
 
 if __name__ == "__main__":

--- a/datman/metrics.py
+++ b/datman/metrics.py
@@ -44,7 +44,7 @@ class Metric(ABC):
         if os.path.exists(self.manifest_path):
             if not overwrite:
                 return
-            orig = self.read_json()
+            orig = self.read_manifest()
         else:
             orig = None
 


### PR DESCRIPTION
This PR fixes:

- A `dm_qc_report.py` doc string error telling users to load `MATLAB` instead of our actual module `matlab` (76634df517a7aaf0e27e7105afad64a77555e3ec)
- A function name typo that caused crashes when running `dm_qc_report.py` with the `--remake` flag (5a7d378ebc83ab627f76e5677239bc38611983e4)
- A recurring issue with `dm_qc_report.py` queue jobs timing out for very large scans (59f882c6543b3fd53c5fa46ea022e186c1540d9e)
- A bug that stopped regeneration of existing QC files when running `dm_qc_report.py` with the `--remake` flag (3f6a409881cfabf7dc85798fc6451b138b4feb2e, bfadd08faef872e4f2a0a7ad39acf1cac97644ae)

This PR adds:

- A `--refresh` flag so that header differences (and scan lengths) can be forced to be recalculated without having to delete existing files or waiting for all metrics to regenerate. This is useful when the `IgnoreHeaderFields` or `HeaderFieldTolerance` settings are updated in the config files and differences need to be cleared out in response. (dae19f53c403e05741bd02e5533298ae0ecbe19c)
