### PR TITLE
[FIX] XNAT import: replace unsupported prearchive=false with Direct-Archive=true

### DIFF
--- a/datman/xnat.py
+++ b/datman/xnat.py
@@ -706,7 +706,7 @@ class XNAT:
         upload_url = (
             f"{self.server}/data/services/import?project={project}"
             f"&subject={subject}&session={experiment}&overwrite=delete"
-            "&prearchive=false&Ignore-Unparsable=true&inbody=true")
+            "&Direct-Archive=true&Ignore-Unparsable=true&inbody=true")
 
         try:
             with open(filename, "rb") as data:


### PR DESCRIPTION
### Description

Fixes DICOM upload to truly bypass prearchive by using the documented flag.

### Change

```
- "&prearchive=false&Ignore-Unparsable=true&inbody=true"
+ "&Direct-Archive=true&Ignore-Unparsable=true&inbody=true"
```

### Impact

Uploads go direct-to-archive.

### Compatibility

Requires XNAT 1.8.3+.

### Reference 

https://wiki.xnat.org/xnat-api/image-session-import-service-api
